### PR TITLE
chore(deps): upgrade HomeAssistant to 2026.5.3 and CI to Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  PYTHON_VERSION: "3.13"
+  PYTHON_VERSION: "3.14"
 
 jobs:
   lint:
@@ -24,7 +24,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Cache pip packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.14"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -53,7 +53,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements*.txt') }}

--- a/custom_components/sunlit/api_client.py
+++ b/custom_components/sunlit/api_client.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
 import aiohttp
-import async_timeout
 
 from .const import (
     API_BASE_URL,
@@ -106,7 +106,7 @@ class SunlitApiClient:
         headers = self._build_headers()
 
         try:
-            async with async_timeout.timeout(self._timeout):
+            async with asyncio.timeout(self._timeout):
                 async with self._session.request(
                     method,
                     url,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Home Assistant Core
 colorlog==6.10.1
-homeassistant==2026.2.3
+homeassistant==2026.5.3
 pip>=26.1.1
 xmltodict>=1.0.4
 charset_normalizer>=3.4.7
 pycountry>=26.2.16
-aiohttp>=3.8.0
+aiohttp>=3.13.5


### PR DESCRIPTION
Consolidates three open dependabot PRs that were mutually blocked, plus the upgrades they require.

## Why
- **#137** bumps `homeassistant` 2026.2.3 → **2026.5.3**, but HA 2026.5.3 **requires Python ≥ 3.14.2** while CI ran 3.13. Newer HA also no longer ships `async_timeout`, which `api_client.py` imported.
- **#122** raises the `aiohttp` floor to `>=3.13.5`, which was *unsatisfiable* against HA 2026.2.3 (pins `aiohttp==3.13.3`). It only resolves once HA is bumped (2026.5.3 pins aiohttp 3.13.5).
- **#83** bumps `actions/cache` v4 → v5 (independent; its red check was a stale run from Dec 2025).

## Changes
- CI `PYTHON_VERSION` and test matrix: **3.13 → 3.14**
- `api_client.py`: `async_timeout.timeout` → stdlib `asyncio.timeout` (Python 3.11+, what HA uses now)
- `requirements.txt`: `homeassistant` 2026.2.3 → 2026.5.3, `aiohttp` `>=3.8.0` → `>=3.13.5`
- `actions/cache` v4 → v5

## Verification
Reproduced locally in a clean Python 3.14 venv with all bumps applied: **162 tests pass**, lint/format clean. The `asyncio.timeout` change is backward-compatible (also passes on 3.13).

Supersedes #137, #122, #83.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to use Python 3.14 and upgraded cache action to version 5.
  * Upgraded package dependencies: homeassistant (2026.2.3 → 2026.5.3) and aiohttp (3.8.0 → 3.13.5).
  * Improved request timeout handling implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/ha-sunlit/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->