### PR TITLE
fix: remove unsupported account-wide device listing (#95)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Credentials for scripts/verify-api.sh — copy to .env (gitignored) and fill in.
+# Use EITHER email + password (the script logs in) OR a pre-obtained token.
+
+SUNLIT_EMAIL=you@example.com
+SUNLIT_PASSWORD=your-password
+
+# Alternative to email/password — a bearer access_token:
+# SUNLIT_TOKEN=eyJ...
+
+# Optional: override the API base URL (default below).
+# SUNLIT_BASE_URL=https://api.sunlitsolar.de/rest

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ __pycache__/
 .coverage
 coverage.xml
 htmlcov
+
+# Local secrets (e.g. Sunlit API credentials for scripts/verify-api.sh)
+.env
+.env.local

--- a/custom_components/sunlit/__init__.py
+++ b/custom_components/sunlit/__init__.py
@@ -152,56 +152,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "mppt": mppt_coordinator,
         }
 
-    # Check for devices without a spaceId (global/unassigned devices)
-    try:
-        all_devices = await api_client.get_device_list()
-        unassigned_devices = [d for d in all_devices if d.get("spaceId") is None]
-
-        if unassigned_devices:
-            _LOGGER.info(
-                "Found %d unassigned devices (no spaceId), creating global coordinator",
-                len(unassigned_devices),
-            )
-            # Create specialized coordinators for global devices
-            global_family_coordinator = SunlitFamilyCoordinator(
-                hass,
-                api_client=api_client,
-                family_id="global",
-                family_name="Unassigned Devices",
-                is_global=True,
-            )
-            await global_family_coordinator.async_config_entry_first_refresh()
-
-            # Create event manager for global devices if enabled
-            global_event_manager = None
-            if soc_events_enabled:
-                global_event_manager = SunlitEventManager(
-                    hass,
-                    family_id="global",
-                    config_options=soc_event_options,
-                )
-                event_managers["global"] = global_event_manager
-
-            global_device_coordinator = SunlitDeviceCoordinator(
-                hass,
-                api_client=api_client,
-                family_id="global",
-                family_name="Unassigned Devices",
-                is_global=True,
-                event_manager=global_event_manager,
-            )
-            await global_device_coordinator.async_config_entry_first_refresh()
-
-            # Note: No strategy or MPPT coordinators for global devices
-            coordinators["global"] = {
-                "family": global_family_coordinator,
-                "device": global_device_coordinator,
-                "strategy": None,  # Not applicable for global devices
-                "mppt": None,  # Not applicable for global devices
-            }
-    except Exception as err:
-        _LOGGER.warning("Failed to check for unassigned devices: %s", err)
-
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
         "coordinators": coordinators,

--- a/custom_components/sunlit/api_client.py
+++ b/custom_components/sunlit/api_client.py
@@ -38,6 +38,23 @@ class SunlitConnectionError(SunlitApiError):
     """Exception for connection errors."""
 
 
+def _format_api_message(message: Any) -> str:
+    """Render an API error message into a readable string.
+
+    The Sunlit API returns localized error messages as a dict keyed by
+    language code, e.g. ``{"DE": "Fehler: ..."}``. Logging that raw makes
+    error lines hard to read, so pick a single human-readable string,
+    preferring English when available.
+    """
+    if isinstance(message, dict):
+        for lang in ("EN", "en", "DE", "de"):
+            if message.get(lang):
+                return str(message[lang])
+        # Unknown language keys: fall back to the first value, then the dict.
+        return str(next(iter(message.values()), message))
+    return str(message)
+
+
 class SunlitApiClient:
     """Client for interacting with the Sunlit Solar API."""
 
@@ -126,7 +143,9 @@ class SunlitApiClient:
 
                     # Check for API-level errors
                     if isinstance(data, dict) and data.get("code") != 0:
-                        message = data.get("message", "Unknown error")
+                        message = _format_api_message(
+                            data.get("message", "Unknown error")
+                        )
                         raise SunlitApiError(f"API error: {message}")
 
                     # Log full response for debugging
@@ -632,32 +651,6 @@ class SunlitApiClient:
             _LOGGER.error(
                 "Failed to fetch strategy history for family %s: %s", family_id, err
             )
-            raise
-
-    async def get_device_list(self) -> list[dict[str, Any]]:
-        """Fetch all devices without filtering by space.
-
-        Returns:
-            List of all devices in the account
-
-        Raises:
-            SunlitAuthError: Authentication failed
-            SunlitConnectionError: Connection failed
-            SunlitApiError: API returned an error
-        """
-        try:
-            response = await self._make_request("POST", API_DEVICE_LIST)
-
-            # Extract devices from paginated response
-            if "content" in response and "content" in response["content"]:
-                devices = response["content"]["content"]
-                _LOGGER.debug("Fetched %d total devices", len(devices))
-                return devices
-
-            return []
-
-        except SunlitApiError as err:
-            _LOGGER.error("Failed to fetch all devices: %s", err)
             raise
 
     async def fetch_space_index(self, space_id: str | int) -> dict[str, Any]:

--- a/custom_components/sunlit/coordinators/device.py
+++ b/custom_components/sunlit/coordinators/device.py
@@ -25,14 +25,12 @@ class SunlitDeviceCoordinator(DataUpdateCoordinator):
         api_client: SunlitApiClient,
         family_id: str,
         family_name: str,
-        is_global: bool = False,
         event_manager: SunlitEventManager | None = None,
     ) -> None:
         """Initialize the device coordinator."""
         self.api_client = api_client
         self.family_id = family_id
         self.family_name = family_name
-        self.is_global = is_global
         self.devices = {}  # Store device info for registry
         self.event_manager = event_manager
 
@@ -87,11 +85,7 @@ class SunlitDeviceCoordinator(DataUpdateCoordinator):
         """Fetch device-level data from REST API."""
         try:
             # Fetch device list
-            if self.is_global:
-                all_devices = await self.api_client.get_device_list()
-                devices = [d for d in all_devices if d.get("spaceId") is None]
-            else:
-                devices = await self.api_client.fetch_device_list(self.family_id)
+            devices = await self.api_client.fetch_device_list(self.family_id)
 
             _LOGGER.debug(
                 "Received %d devices for family %s", len(devices), self.family_name

--- a/custom_components/sunlit/coordinators/family.py
+++ b/custom_components/sunlit/coordinators/family.py
@@ -24,13 +24,11 @@ class SunlitFamilyCoordinator(DataUpdateCoordinator):
         api_client: SunlitApiClient,
         family_id: str,
         family_name: str,
-        is_global: bool = False,
     ) -> None:
         """Initialize the family coordinator."""
         self.api_client = api_client
         self.family_id = family_id
         self.family_name = family_name
-        self.is_global = is_global
         self.devices = {}  # Empty for compatibility with legacy code
 
         super().__init__(
@@ -84,20 +82,6 @@ class SunlitFamilyCoordinator(DataUpdateCoordinator):
         """Fetch family-level data from REST API."""
         try:
             family_data = {}
-
-            if self.is_global:
-                # For global/unassigned devices, minimal family data
-                all_devices = await self.api_client.get_device_list()
-                devices = [d for d in all_devices if d.get("spaceId") is None]
-
-                family_data["device_count"] = len(devices)
-                family_data["online_devices"] = sum(
-                    1 for d in devices if d.get("status") == "Online"
-                )
-                family_data["offline_devices"] = sum(
-                    1 for d in devices if d.get("status") == "Offline"
-                )
-                return {"family": family_data}
 
             # Fetch space index for comprehensive family data
             space_index = {}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -98,8 +98,11 @@ paths:
                   example: 12345
                 deviceType:
                   type: string
-                  description: Device type filter (use "" for all types)
-                  example: ""
+                  description: >-
+                    Device type filter. Use "ALL" for all types (the API
+                    rejects an empty string with code 400000). Specific types
+                    include ENERGY_STORAGE_BATTERY, SHELLY_3EM_METER, etc.
+                  example: "ALL"
       responses:
         "200":
           description: Successful response

--- a/scripts/verify-api.sh
+++ b/scripts/verify-api.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+#
+# verify-api.sh — probe the Sunlit REST API to validate assumptions behind
+# issue #95 ("Ungültige sonstige Parameter" at startup).
+#
+# It answers, with real responses:
+#   1. Does POST /v1.2/device/list fail WITHOUT a body? (the #95 error)
+#   2. Does it succeed WITH {familyId, deviceType}? (the documented contract)
+#   3. Does deviceType "ALL" work, or does the API want "" (per openapi.yaml)?
+#   4. Are there any devices with spaceId == null across all families?
+#      (decides whether "aggregate across families" can find unassigned devices)
+#   5. Is the error `message` field a localized dict ({"DE": ...})?
+#
+# Usage:
+#   Auth with credentials (logs in, prints nothing secret):
+#     SUNLIT_EMAIL=you@example.com SUNLIT_PASSWORD=secret ./scripts/verify-api.sh
+#   Or reuse an existing bearer token:
+#     SUNLIT_TOKEN=eyJ... ./scripts/verify-api.sh
+#
+# Optional:
+#   SUNLIT_BASE_URL  override API base (default: https://api.sunlitsolar.de/rest)
+
+set -uo pipefail
+
+BASE_URL="${SUNLIT_BASE_URL:-https://api.sunlitsolar.de/rest}"
+UA="ha-sunlit-verify/1.0 (+https://github.com/cedricziel/ha-sunlit)"
+
+# ---- pretty output ---------------------------------------------------------
+if [[ -t 1 ]]; then
+  BOLD=$'\033[1m'; GREEN=$'\033[32m'; RED=$'\033[31m'; YELLOW=$'\033[33m'; DIM=$'\033[2m'; RESET=$'\033[0m'
+else
+  BOLD=""; GREEN=""; RED=""; YELLOW=""; DIM=""; RESET=""
+fi
+section() { printf '\n%s== %s ==%s\n' "$BOLD" "$1" "$RESET"; }
+pass()    { printf '%s  PASS%s %s\n' "$GREEN" "$RESET" "$1"; }
+fail()    { printf '%s  FAIL%s %s\n' "$RED" "$RESET" "$1"; }
+note()    { printf '%s  %s%s\n' "$DIM" "$1" "$RESET"; }
+
+# ---- dependencies ----------------------------------------------------------
+for dep in curl jq; do
+  command -v "$dep" >/dev/null 2>&1 || { echo "Error: '$dep' is required." >&2; exit 1; }
+done
+
+# ---- load .env (gitignored) ------------------------------------------------
+# Looks for $SUNLIT_ENV_FILE, else .env in the repo root (script's parent dir),
+# else .env in the current directory. Already-set environment variables win.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${SUNLIT_ENV_FILE:-}"
+if [[ -z "$ENV_FILE" ]]; then
+  for candidate in "$REPO_ROOT/.env" "./.env"; do
+    [[ -f "$candidate" ]] && { ENV_FILE="$candidate"; break; }
+  done
+fi
+if [[ -n "$ENV_FILE" && -f "$ENV_FILE" ]]; then
+  note "loading credentials from $ENV_FILE"
+  while IFS='=' read -r key val; do
+    key="${key#"${key%%[![:space:]]*}"}"        # ltrim
+    [[ -z "$key" || "$key" == \#* ]] && continue # skip blanks/comments
+    [[ -n "${!key:-}" ]] && continue             # existing env wins
+    val="${val%$'\r'}"                           # tolerate CRLF
+    val="${val#[\"\']}"; val="${val%[\"\']}"     # strip one layer of quotes
+    export "$key=$val"
+  done < "$ENV_FILE"
+fi
+
+# ---- request helper --------------------------------------------------------
+# request METHOD PATH [JSON_BODY]  -> prints body, then a final line with HTTP status.
+request() {
+  local method="$1" path="$2" body="${3-}"
+  local args=(-sS -X "$method" -H "User-Agent: $UA" -H "Content-Type: application/json")
+  [[ -n "${TOKEN:-}" ]] && args+=(-H "Authorization: Bearer $TOKEN")
+  [[ "${3+set}" == "set" ]] && args+=(--data "$body")
+  curl "${args[@]}" -w $'\n%{http_code}' "$BASE_URL$path"
+}
+http_of() { tail -n1 <<<"$1"; }
+body_of() { sed '$d' <<<"$1"; }
+code_of() { jq -r '.code // "?"' <<<"$1" 2>/dev/null; }
+msg_of()  { jq -rc '.message // ""' <<<"$1" 2>/dev/null; }
+
+# ---- authenticate ----------------------------------------------------------
+section "Auth"
+TOKEN="${SUNLIT_TOKEN:-}"
+if [[ -z "$TOKEN" ]]; then
+  : "${SUNLIT_EMAIL:?set SUNLIT_EMAIL + SUNLIT_PASSWORD, or SUNLIT_TOKEN}"
+  : "${SUNLIT_PASSWORD:?set SUNLIT_EMAIL + SUNLIT_PASSWORD, or SUNLIT_TOKEN}"
+  login_payload=$(jq -nc --arg a "$SUNLIT_EMAIL" --arg p "$SUNLIT_PASSWORD" '{account:$a,password:$p}')
+  resp=$(request POST /user/login "$login_payload")
+  jbody=$(body_of "$resp")
+  TOKEN=$(jq -r '.content.access_token // empty' <<<"$jbody")
+  if [[ -z "$TOKEN" ]]; then
+    fail "login failed (HTTP $(http_of "$resp"), code $(code_of "$jbody"), message $(msg_of "$jbody"))"
+    exit 1
+  fi
+  pass "logged in as $SUNLIT_EMAIL (token ${TOKEN:0:6}…, ${#TOKEN} chars)"
+else
+  pass "using SUNLIT_TOKEN (${TOKEN:0:6}…, ${#TOKEN} chars)"
+fi
+
+# ---- families --------------------------------------------------------------
+section "GET /family/list"
+resp=$(request GET /family/list)
+fbody=$(body_of "$resp")
+if [[ "$(code_of "$fbody")" != "0" ]]; then
+  fail "HTTP $(http_of "$resp"), code $(code_of "$fbody"), message $(msg_of "$fbody")"
+  exit 1
+fi
+FAMILY_IDS=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && FAMILY_IDS+=("$line")
+done < <(jq -r '.content[].id' <<<"$fbody")
+if [[ ${#FAMILY_IDS[@]} -eq 0 ]]; then
+  fail "no families returned for this account"
+  exit 1
+fi
+pass "${#FAMILY_IDS[@]} families: ${FAMILY_IDS[*]}"
+jq -r '.content[] | "    family \(.id)  \(.name)  deviceCount=\(.deviceCount // "?")"' <<<"$fbody"
+FID="${FAMILY_IDS[0]}"
+
+# ---- device/list WITHOUT body (reproduces #95) -----------------------------
+section "POST /v1.2/device/list  — no body (issue #95)"
+resp=$(request POST /v1.2/device/list)          # note: no 3rd arg -> no --data
+dbody=$(body_of "$resp")
+dcode=$(code_of "$dbody")
+if [[ "$dcode" == "0" ]]; then
+  fail "expected rejection but got code 0 — bodyless call actually works?!"
+else
+  pass "rejected as expected: HTTP $(http_of "$resp"), code $dcode"
+  note "message: $(msg_of "$dbody")"
+  if jq -e '.message | type == "object"' <<<"$dbody" >/dev/null 2>&1; then
+    note "→ message is a localized OBJECT (e.g. {\"DE\": …}); api_client logs it raw"
+  fi
+fi
+
+# ---- device/list with deviceType "ALL" (what the code sends) ---------------
+section "POST /v1.2/device/list  — {familyId:$FID, deviceType:\"ALL\"}"
+resp=$(request POST /v1.2/device/list "$(jq -nc --argjson f "$FID" '{familyId:$f,deviceType:"ALL"}')")
+abody=$(body_of "$resp")
+if [[ "$(code_of "$abody")" == "0" ]]; then
+  pass "code 0, $(jq '.content.content | length' <<<"$abody") devices"
+else
+  fail "code $(code_of "$abody"): $(msg_of "$abody")  (does the API reject \"ALL\"?)"
+fi
+
+# ---- device/list with deviceType "" (what openapi.yaml documents) ----------
+section "POST /v1.2/device/list  — {familyId:$FID, deviceType:\"\"}"
+resp=$(request POST /v1.2/device/list "$(jq -nc --argjson f "$FID" '{familyId:$f,deviceType:""}')")
+ebody=$(body_of "$resp")
+if [[ "$(code_of "$ebody")" == "0" ]]; then
+  pass "code 0, $(jq '.content.content | length' <<<"$ebody") devices"
+else
+  fail "code $(code_of "$ebody"): $(msg_of "$ebody")"
+fi
+
+# ---- device/list with deviceType only, no familyId -------------------------
+section "POST /v1.2/device/list  — {deviceType:\"ALL\"} (missing familyId)"
+resp=$(request POST /v1.2/device/list '{"deviceType":"ALL"}')
+nbody=$(body_of "$resp")
+if [[ "$(code_of "$nbody")" == "0" ]]; then
+  note "accepted without familyId (returned $(jq '.content.content | length' <<<"$nbody") devices)"
+else
+  pass "rejected without familyId: code $(code_of "$nbody"), $(msg_of "$nbody")"
+fi
+
+# ---- spaceId survey across ALL families ------------------------------------
+section "spaceId survey (decides the #95 fix)"
+total=0; nullspace=0
+for fid in "${FAMILY_IDS[@]}"; do
+  resp=$(request POST /v1.2/device/list "$(jq -nc --argjson f "$fid" '{familyId:$f,deviceType:"ALL"}')")
+  fb=$(body_of "$resp")
+  [[ "$(code_of "$fb")" == "0" ]] || { note "family $fid: error $(msg_of "$fb")"; continue; }
+  cnt=$(jq '.content.content | length' <<<"$fb")
+  nul=$(jq '[.content.content[] | select(.spaceId == null)] | length' <<<"$fb")
+  total=$((total + cnt)); nullspace=$((nullspace + nul))
+  note "family $fid: $cnt devices, $nul with spaceId=null"
+  jq -r '.content.content[] | "      device \(.deviceId)  type=\(.deviceType)  spaceId=\(.spaceId)"' <<<"$fb"
+done
+
+section "Summary for #95"
+echo "  • Total devices across families: $total"
+echo "  • Devices with spaceId == null:  $nullspace"
+if (( nullspace > 0 )); then
+  echo "  → 'Aggregate across families' WOULD find unassigned devices."
+else
+  echo "  → No spaceId=null devices found via family-scoped calls; the"
+  echo "    'unassigned devices' feature cannot work via this endpoint →"
+  echo "    favor removing it / silencing the bodyless call."
+fi

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -11,6 +11,7 @@ from custom_components.sunlit.api_client import (
     SunlitApiError,
     SunlitAuthError,
     SunlitConnectionError,
+    _format_api_message,
 )
 
 
@@ -133,6 +134,67 @@ async def test_fetch_families_api_error(api_client, mock_session):
         await api_client.fetch_families()
 
     assert "API error: Something went wrong" in str(exc_info.value)
+
+
+def test_format_api_message_plain_string():
+    """A plain string message is returned unchanged."""
+    assert _format_api_message("Something went wrong") == "Something went wrong"
+
+
+def test_format_api_message_localized_dict_prefers_english():
+    """When multiple languages are present, English is preferred."""
+    assert (
+        _format_api_message({"DE": "Fehler", "EN": "Error"}) == "Error"
+    )
+
+
+def test_format_api_message_localized_dict_german_only():
+    """A German-only localized message (issue #95) is rendered as its text.
+
+    Regression for #95: the API returns ``{"DE": "..."}`` and we must log the
+    readable string, not the raw dict.
+    """
+    msg = {
+        "DE": "Fehler: Ungültige sonstige Parameter. Wenn dieser Fehler "
+        "weiterhin besteht, wenden Sie sich bitte an unseren Kundensupport."
+    }
+    rendered = _format_api_message(msg)
+    assert rendered.startswith("Fehler: Ungültige sonstige Parameter")
+    assert "{" not in rendered  # not the raw dict
+
+
+def test_format_api_message_unknown_language_falls_back_to_value():
+    """Unknown language keys fall back to the first available value."""
+    assert _format_api_message({"fr": "Erreur"}) == "Erreur"
+
+
+@pytest.mark.asyncio
+async def test_api_error_renders_localized_message(api_client, mock_session):
+    """Regression for #95: a localized error dict surfaces as readable text.
+
+    The Sunlit API returns ``code != 0`` with a localized ``message`` dict.
+    The raised SunlitApiError must contain the human-readable string rather
+    than the raw ``{'DE': ...}`` repr.
+    """
+    setup_mock_response(
+        mock_session,
+        200,
+        {
+            "code": 400000,
+            "message": {
+                "DE": "Fehler: Ungültige sonstige Parameter. Wenn dieser "
+                "Fehler weiterhin besteht, wenden Sie sich bitte an unseren "
+                "Kundensupport."
+            },
+        },
+    )
+
+    with pytest.raises(SunlitApiError) as exc_info:
+        await api_client.fetch_device_list(34038)
+
+    err = str(exc_info.value)
+    assert "Ungültige sonstige Parameter" in err
+    assert "{'DE'" not in err  # raw dict repr must not leak into the message
 
 
 @pytest.mark.asyncio

--- a/tests/test_device_coordinator.py
+++ b/tests/test_device_coordinator.py
@@ -134,47 +134,6 @@ async def test_device_coordinator_offline_devices(
     api_client.fetch_device_statistics.assert_not_called()
 
 
-async def test_device_coordinator_global_devices(
-    hass: HomeAssistant,
-    enable_custom_integrations,
-):
-    """Test device coordinator for global/unassigned devices."""
-    api_client = AsyncMock()
-    api_client.get_device_list.return_value = [
-        {
-            "deviceId": "dev1",
-            "deviceType": "SHELLY_3EM_METER",
-            "spaceId": None,
-            "status": "Online",
-        },
-        {
-            "deviceId": "dev2",
-            "deviceType": "YUNENG_MICRO_INVERTER",
-            "spaceId": "123",  # Has spaceId, should be filtered
-            "status": "Online",
-        },
-    ]
-    api_client.fetch_device_statistics.return_value = {}
-
-    coordinator = SunlitDeviceCoordinator(
-        hass,
-        api_client,
-        "global",
-        "Unassigned Devices",
-        is_global=True,
-    )
-
-    data = await coordinator._async_update_data()
-
-    assert data is not None
-    devices = data["devices"]
-
-    # Should only include device without spaceId
-    assert len(devices) == 1
-    assert "dev1" in devices
-    assert "dev2" not in devices
-
-
 async def test_device_coordinator_inverter_variations(
     hass: HomeAssistant,
     enable_custom_integrations,

--- a/tests/test_family_coordinator.py
+++ b/tests/test_family_coordinator.py
@@ -66,42 +66,6 @@ async def test_family_coordinator_update_success(
     api_client.get_charging_box_strategy.assert_called_once_with("34038")
 
 
-async def test_family_coordinator_global_devices(
-    hass: HomeAssistant,
-    enable_custom_integrations,
-):
-    """Test family coordinator for global/unassigned devices."""
-    api_client = AsyncMock()
-    api_client.get_device_list.return_value = [
-        {"deviceId": "dev1", "spaceId": None, "status": "Online"},
-        {"deviceId": "dev2", "spaceId": None, "status": "Offline"},
-        {"deviceId": "dev3", "spaceId": "123", "status": "Online"},  # Has spaceId, should be filtered
-    ]
-
-    coordinator = SunlitFamilyCoordinator(
-        hass,
-        api_client,
-        "global",
-        "Unassigned Devices",
-        is_global=True,
-    )
-
-    data = await coordinator._async_update_data()
-
-    assert data is not None
-    assert "family" in data
-    family_data = data["family"]
-
-    # Should only count devices without spaceId
-    assert family_data["device_count"] == 2
-    assert family_data["online_devices"] == 1
-    assert family_data["offline_devices"] == 1
-
-    # Should not call space-specific APIs
-    api_client.fetch_space_index.assert_not_called()
-    api_client.fetch_space_soc.assert_not_called()
-
-
 async def test_family_coordinator_partial_failure(
     hass: HomeAssistant,
     enable_custom_integrations,


### PR DESCRIPTION
Fixes #95 — the `Ungültige sonstige Parameter` error logged on every Home Assistant startup.

## Root cause (verified against the live API)
The "unassigned / global devices" feature (added in #28) called `POST /v1.2/device/list` **with no request body**. That endpoint requires `familyId` + `deviceType`, so the Sunlit API rejected every call with `code 400000`, which surfaced as an **ERROR** (`api_client.py`) + **WARNING** (`__init__.py`) at startup. The integration still worked, but the logs were alarming.

I added `scripts/verify-api.sh` and probed a real account. The data was conclusive:

| Probe | Result |
|-------|--------|
| `device/list` with no body | `code 400000`, `{"DE":"…Ungültige sonstige Parameter…"}` — reproduces #95 |
| `device/list` with `deviceType:""` | **rejected** (`code 400000`) — the value `openapi.yaml` documented |
| `device/list` with `deviceType:"ALL"` | ✅ works (what the code already sends) |
| `device/list` missing `familyId` | `{"DE":"Familien-ID darf nicht null sein"}` — familyId is mandatory |
| `spaceId` survey across all families | **0** devices with `spaceId == null`; `spaceId` mirrors `familyId` |

→ There is no account-wide device listing, and "unassigned" (`spaceId=null`) devices don't exist in this data model. The feature can't work via this endpoint, so it's removed rather than patched.

## Changes
- **Remove** `get_device_list()` and the global `SunlitFamily`/`SunlitDevice` coordinator wiring, plus the `is_global` path/param from both coordinators and the "unassigned devices" block in `__init__.py`. Kills the startup ERROR/WARNING and removes dead code.
- **Render localized error messages**: `{"DE": "..."}` now logs as readable text (prefer English) instead of the raw dict.
- **Fix `openapi.yaml`**: `device/list` `deviceType` example `""` → `"ALL"` (the spec, not the code, was wrong).
- **Tests**: drop the obsolete global-device tests; add regression tests for localized message rendering. 165 passed, coverage 72%.
- **Tooling**: add `scripts/verify-api.sh` (curl + jq, loads gitignored `.env`) for future API debugging.

## Caveat
Probed on a single-account/one-device setup. But since the endpoint categorically requires `familyId`, the account-wide call cannot work regardless of multi-space behavior.