### PR TITLE
fix: persist MPPT energy accumulators across restarts

### DIFF
--- a/custom_components/sunlit/coordinators/mppt.py
+++ b/custom_components/sunlit/coordinators/mppt.py
@@ -7,12 +7,18 @@ import logging
 import time
 from typing import Any
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
+from ..const import DOMAIN
 from .device import SunlitDeviceCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+STORAGE_VERSION = 1
+# Debounce window for persisting accumulators after an update.
+SAVE_DELAY = 30
 
 
 class SunlitMpptEnergyCoordinator(DataUpdateCoordinator):
@@ -35,6 +41,12 @@ class SunlitMpptEnergyCoordinator(DataUpdateCoordinator):
         self.last_mppt_update = {}
         self.last_mppt_power = {}
 
+        # Persist accumulators so lifetime energy survives HA restarts.
+        self._store: Store = Store(
+            hass, STORAGE_VERSION, f"{DOMAIN}_mppt_energy_{family_id}"
+        )
+        self._restored = False
+
         super().__init__(
             hass,
             _LOGGER,
@@ -42,9 +54,37 @@ class SunlitMpptEnergyCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(minutes=1),  # 1 minute updates
         )
 
+    @callback
+    def _data_to_store(self) -> dict[str, Any]:
+        """Return the accumulator state to persist."""
+        return {"mppt_energy": self.mppt_energy}
+
+    async def _async_restore_energy(self) -> None:
+        """Restore persisted MPPT energy accumulators.
+
+        Only the energy totals are restored, deliberately not the per-channel
+        timestamps. Leaving ``last_mppt_update`` empty makes the first tick
+        after a restart record a fresh baseline instead of integrating over the
+        (possibly very large) gap since the last save, which would otherwise
+        inject a bogus one-off energy spike.
+        """
+        stored = await self._store.async_load()
+        if stored and isinstance(stored.get("mppt_energy"), dict):
+            self.mppt_energy = stored["mppt_energy"]
+            _LOGGER.debug(
+                "Restored MPPT energy for %s: %d channels",
+                self.family_name,
+                len(self.mppt_energy),
+            )
+
     async def _async_update_data(self) -> dict[str, Any]:
         """Calculate MPPT energy accumulation."""
         try:
+            # Restore persisted accumulators on the first run after startup.
+            if not self._restored:
+                await self._async_restore_energy()
+                self._restored = True
+
             current_time = time.time()
 
             mppt_data = {}
@@ -78,6 +118,9 @@ class SunlitMpptEnergyCoordinator(DataUpdateCoordinator):
             total_mppt_energy = sum(
                 self.mppt_energy.get(key, 0) for key in self.mppt_energy
             )
+
+            # Persist accumulators (debounced) so they survive restarts.
+            self._store.async_delay_save(self._data_to_store, SAVE_DELAY)
 
             return {
                 "mppt_energy": mppt_data,

--- a/tests/test_mppt_persistence.py
+++ b/tests/test_mppt_persistence.py
@@ -1,0 +1,66 @@
+"""MPPT energy persistence across restarts (issue #72 follow-up).
+
+Driven by the sanitized real battery payload in tests/fixtures/api/.
+"""
+
+from unittest.mock import MagicMock
+
+from custom_components.sunlit.coordinators.mppt import SunlitMpptEnergyCoordinator
+
+from tests.fixtures import load_api_fixture
+
+BATTERY_DEVICE_ID = "10003"
+
+
+def _battery_device_coordinator() -> MagicMock:
+    """A device-coordinator stub serving the real battery statistics."""
+    stats = load_api_fixture("device_statistics_ENERGY_STORAGE_BATTERY_10003")
+    device_data = {**stats, "deviceType": "ENERGY_STORAGE_BATTERY", "module_count": 3}
+    dev = MagicMock()
+    dev.data = {"devices": {BATTERY_DEVICE_ID: device_data}}
+    dev.get_battery_module_count.return_value = 3
+    return dev
+
+
+async def test_mppt_energy_persists_across_restart(hass, hass_storage):
+    """Accumulated energy is restored by a fresh coordinator (simulated restart)."""
+    dev = _battery_device_coordinator()
+
+    # First lifecycle: accumulate energy over a simulated hour.
+    coord_a = SunlitMpptEnergyCoordinator(hass, dev, "10001", "Test Family")
+    await coord_a._async_update_data()
+    for key in list(coord_a.last_mppt_update):
+        coord_a.last_mppt_update[key] -= 3600
+    await coord_a._async_update_data()
+    accumulated = coord_a.mppt_energy["10003_battery1Mppt1Energy"]
+    assert accumulated > 0
+
+    # Flush the debounced save.
+    await coord_a._store.async_save(coord_a._data_to_store())
+
+    # Second lifecycle (restart): a fresh coordinator restores the totals.
+    coord_b = SunlitMpptEnergyCoordinator(hass, dev, "10001", "Test Family")
+    assert coord_b.mppt_energy == {}
+    await coord_b._async_update_data()  # triggers restore on first run
+    assert coord_b.mppt_energy["10003_battery1Mppt1Energy"] == accumulated
+
+
+async def test_no_energy_spike_after_restore(hass, hass_storage):
+    """The first tick after a restart restores the value without a phantom spike.
+
+    Restoring the per-channel timestamp would make the first update integrate
+    over the entire offline period; we restore only the energy totals, so the
+    value must come back unchanged.
+    """
+    coordinator = SunlitMpptEnergyCoordinator(
+        hass, _battery_device_coordinator(), "10001", "Test Family"
+    )
+    # Pre-seed persisted state as if a previous run had accumulated 5 kWh.
+    await coordinator._store.async_save(
+        {"mppt_energy": {"10003_battery1Mppt1Energy": 5.0}}
+    )
+
+    result = await coordinator._async_update_data()
+
+    energy = result["mppt_energy"][BATTERY_DEVICE_ID]
+    assert energy["battery1Mppt1Energy"] == 5.0  # restored, no spike


### PR DESCRIPTION
Follow-up to #72 (#143). The MPPT-energy sensors now accumulate within a session, but the accumulators were in-memory only — every HA restart reset them to 0, so the `total_increasing` "MPPT Total Energy" sensors never built up a real lifetime total.

## Change
Persist the accumulators in `SunlitMpptEnergyCoordinator` via `homeassistant.helpers.storage.Store` (key `sunlit_mppt_energy_{family_id}`):
- **Restore** on the first update after startup.
- **Save** (debounced, 30s) after each update; HA also flushes pending delayed saves on shutdown.

**Spike avoidance:** only the energy totals are restored, *not* the per-channel timestamps. With `last_mppt_update` empty after a restart, the first tick records a fresh baseline instead of integrating over the entire offline gap (which would add a bogus one-off increment).

## Tests (grounded in real captured data)
`tests/test_mppt_persistence.py`, using the sanitized real battery payload:
- **persists across restart** — accumulate, save, then a fresh coordinator restores the same totals.
- **no spike after restore** — a pre-seeded 5 kWh value comes back unchanged on the first post-restart tick (not 0, not 5 + a gap-sized spike).

171 tests pass, lint clean, coverage 72%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MPPT energy totals now persist across Home Assistant restarts, preventing energy data loss during system restarts.

* **Tests**
  * Added comprehensive tests to verify MPPT energy persistence and prevent unintended energy accumulation after restarts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/ha-sunlit/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->