### PR TITLE
feat: add family-level Total MPPT Energy sensor

### DIFF
--- a/custom_components/sunlit/const.py
+++ b/custom_components/sunlit/const.py
@@ -167,6 +167,7 @@ FAMILY_SENSORS = {
     # Total solar production tracking
     "total_solar_energy": "Total Solar Energy",
     "total_solar_power": "Total Solar Power",
+    "total_mppt_energy": "Total MPPT Energy",
     "battery_count": "Battery Module Count",
     "battery_charging_remaining": "Charging Time Remaining",
     "battery_discharging_remaining": "Discharging Time Remaining",

--- a/custom_components/sunlit/entities/family_sensor.py
+++ b/custom_components/sunlit/entities/family_sensor.py
@@ -72,6 +72,11 @@ class SunlitFamilySensor(CoordinatorEntity, SensorEntity):
         if self.coordinator.data:
             value = None
 
+            # MPPT coordinator exposes the family rollup at the top level
+            # (its "mppt_energy" section is keyed by device id, not sensor key).
+            if self.entity_description.key == "total_mppt_energy":
+                return self.coordinator.data.get("total_mppt_energy")
+
             # Check the appropriate section based on coordinator type
             # Device coordinator uses aggregates
             if "aggregates" in self.coordinator.data:
@@ -107,6 +112,8 @@ class SunlitFamilySensor(CoordinatorEntity, SensorEntity):
 
         # Check if the key exists in the appropriate data section
         # Match the order used in native_value for consistency
+        if self.entity_description.key == "total_mppt_energy":
+            return "total_mppt_energy" in self.coordinator.data
         if "aggregates" in self.coordinator.data:
             return self.entity_description.key in self.coordinator.data.get(
                 "aggregates", {}

--- a/custom_components/sunlit/sensor.py
+++ b/custom_components/sunlit/sensor.py
@@ -104,13 +104,17 @@ async def async_setup_entry(
                 ):
                     family_data.update(strategy_coordinator.data["strategy"])
 
-                # Add MPPT energy data if available
+                # Add the family-level MPPT energy total if available.
+                # (mppt_coordinator.data["mppt_energy"] is keyed by device id and
+                # feeds the per-device/module sensors, not family sensors.)
                 if (
                     mppt_coordinator
                     and mppt_coordinator.data
-                    and "mppt_energy" in mppt_coordinator.data
+                    and "total_mppt_energy" in mppt_coordinator.data
                 ):
-                    family_data.update(mppt_coordinator.data["mppt_energy"])
+                    family_data["total_mppt_energy"] = mppt_coordinator.data[
+                        "total_mppt_energy"
+                    ]
 
                 # Add device aggregates if available
                 if (
@@ -142,7 +146,7 @@ async def async_setup_entry(
                                 if strategy_coordinator
                                 else family_coordinator
                             )
-                        elif key.startswith("mppt") and "energy" in key:
+                        elif "mppt" in key and "energy" in key:
                             coord = (
                                 mppt_coordinator
                                 if mppt_coordinator

--- a/tests/test_family_mppt_sensor.py
+++ b/tests/test_family_mppt_sensor.py
@@ -1,0 +1,93 @@
+"""Family-level Total MPPT Energy sensor (issue #72 follow-up).
+
+The MPPT coordinator computes a family rollup (``total_mppt_energy``) but it
+was never surfaced: the merge in sensor.py added device-id-keyed entries to
+``family_data`` instead of the rollup, so no family sensor was created.
+"""
+
+from unittest.mock import MagicMock, Mock
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import UnitOfEnergy
+from homeassistant.core import HomeAssistant
+
+from custom_components.sunlit.const import DOMAIN, FAMILY_SENSORS
+from custom_components.sunlit.coordinators.device import SunlitDeviceCoordinator
+from custom_components.sunlit.coordinators.family import SunlitFamilyCoordinator
+from custom_components.sunlit.coordinators.mppt import SunlitMpptEnergyCoordinator
+from custom_components.sunlit.entities.helpers import (
+    get_device_class_for_sensor,
+    get_state_class_for_sensor,
+    get_unit_for_sensor,
+)
+from custom_components.sunlit.sensor import async_setup_entry
+
+
+def test_total_mppt_energy_registered_and_classified():
+    """The rollup is registered and classified as energy / total_increasing / kWh."""
+    assert "total_mppt_energy" in FAMILY_SENSORS
+    assert get_device_class_for_sensor("total_mppt_energy") == SensorDeviceClass.ENERGY
+    assert (
+        get_state_class_for_sensor("total_mppt_energy")
+        == SensorStateClass.TOTAL_INCREASING
+    )
+    assert get_unit_for_sensor("total_mppt_energy") == UnitOfEnergy.KILO_WATT_HOUR
+
+
+async def test_family_total_mppt_energy_sensor_created(
+    hass: HomeAssistant,
+    mock_config_entry,
+):
+    """async_setup_entry creates the family rollup sensor bound to the MPPT coordinator."""
+    mock_config_entry.add_to_hass(hass)
+
+    family_coordinator = MagicMock(spec=SunlitFamilyCoordinator)
+    family_coordinator.family_id = "10001"
+    family_coordinator.family_name = "Test Family"
+    family_coordinator.devices = {}
+    family_coordinator.data = {"family": {"device_count": 1}}
+
+    device_coordinator = MagicMock(spec=SunlitDeviceCoordinator)
+    device_coordinator.family_id = "10001"
+    device_coordinator.family_name = "Test Family"
+    device_coordinator.devices = {}
+    device_coordinator.data = {"devices": {}, "aggregates": {}}
+
+    mppt_coordinator = MagicMock(spec=SunlitMpptEnergyCoordinator)
+    mppt_coordinator.family_id = "10001"
+    mppt_coordinator.family_name = "Test Family"
+    mppt_coordinator.last_update_success = True
+    mppt_coordinator.data = {
+        "mppt_energy": {"10003": {"battery1Mppt1Energy": 0.5}},
+        "total_mppt_energy": 2.5,
+    }
+
+    hass.data[DOMAIN] = {
+        mock_config_entry.entry_id: {
+            "10001": {
+                "family": family_coordinator,
+                "device": device_coordinator,
+                "strategy": None,
+                "mppt": mppt_coordinator,
+            }
+        }
+    }
+
+    async_add_entities = Mock()
+    await async_setup_entry(hass, mock_config_entry, async_add_entities)
+
+    sensors = async_add_entities.call_args[0][0]
+    by_key = {
+        s.entity_description.key: s
+        for s in sensors
+        if hasattr(s, "entity_description")
+    }
+
+    assert "total_mppt_energy" in by_key, "family Total MPPT Energy sensor not created"
+    sensor = by_key["total_mppt_energy"]
+    # Must be bound to the MPPT coordinator (so HA keeps it polling, too).
+    assert sensor.coordinator is mppt_coordinator
+    assert sensor.entity_description.device_class == SensorDeviceClass.ENERGY
+    # Reads the top-level rollup, not the nested per-device dict.
+    assert sensor.native_value == 2.5
+    assert sensor.available is True


### PR DESCRIPTION
Follow-up to #72. The MPPT coordinator already computes a family rollup (`total_mppt_energy`), but it was **never exposed as a sensor**.

## Why it was missing
`sensor.py` merged `mppt_coordinator.data["mppt_energy"]` into `family_data` — but that dict is keyed by **device id** (e.g. `"10003"`), so no key matched `FAMILY_SENSORS` and no family sensor was created. The actual rollup `total_mppt_energy` was never merged at all.

## Change
- Register `total_mppt_energy` in `FAMILY_SENSORS` (classified as energy / `total_increasing` / kWh by the existing `"mpptenergy"` rule — no helper change needed).
- Merge the **rollup** (not the per-device dict) into `family_data`, and route MPPT energy keys to the MPPT coordinator (match `"mppt"` anywhere in the key, not just as a prefix, so `total_mppt_energy` qualifies).
- `SunlitFamilySensor` now reads the top-level `total_mppt_energy` instead of reaching into the nested per-device `mppt_energy` dict.

Bonus: binding this sensor to the MPPT coordinator gives it another listener, reinforcing the #72 fix that keeps the coordinator polling.

## Tests
`tests/test_family_mppt_sensor.py`:
- classification (energy / total_increasing / kWh) + `FAMILY_SENSORS` membership,
- `async_setup_entry` actually **creates** the family sensor, binds it to the MPPT coordinator, and `native_value` returns the rollup (`2.5`).

171 tests pass, lint clean, coverage 72%.