### PR TITLE
feat: discover BK215 batteries via zeroconf

### DIFF
--- a/custom_components/sunlit/config_flow.py
+++ b/custom_components/sunlit/config_flow.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.selector import (
     NumberSelectorConfig,
     NumberSelectorMode,
 )
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 import voluptuous as vol
 
 from .api_client import SunlitApiClient, SunlitAuthError, SunlitConnectionError
@@ -66,6 +67,55 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.access_token: str | None = None
         self.families: dict[str, Any] = {}
         self.available_families: list[dict[str, Any]] = []
+        self._discovered_serial: str | None = None
+
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> FlowResult:
+        """Handle a battery discovered via mDNS/zeroconf.
+
+        The BK215 (Highpower) advertises itself on the local network as
+        ``hp-bk215*`` over ``_http._tcp.local.``. This integration is
+        cloud-polling, so discovery only acts as an onboarding trigger:
+        we surface the device and then funnel the user into the normal
+        cloud credential flow. The discovered serial is recorded so a
+        future opt-in local-polling mode can reuse it.
+        """
+        properties = discovery_info.properties
+        self._discovered_serial = properties.get("id")
+
+        # Dedupe concurrent discovery flows for the same battery.
+        await self.async_set_unique_id(self._discovered_serial or DOMAIN)
+        self._abort_if_unique_id_configured()
+
+        # Single-entry integration: one cloud account covers every device,
+        # so once anything is set up there is nothing more to discover.
+        if self._async_current_entries():
+            return self.async_abort(reason="already_configured")
+
+        self.context["title_placeholders"] = {
+            "name": (
+                f"Sunlit BK215 ({self._discovered_serial})"
+                if self._discovered_serial
+                else "Sunlit BK215"
+            )
+        }
+
+        return await self.async_step_zeroconf_confirm()
+
+    async def async_step_zeroconf_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm a discovered battery and continue to cloud login."""
+        if user_input is not None:
+            return await self.async_step_user()
+
+        return self.async_show_form(
+            step_id="zeroconf_confirm",
+            description_placeholders={
+                "serial_number": self._discovered_serial or "unknown"
+            },
+        )
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/sunlit/manifest.json
+++ b/custom_components/sunlit/manifest.json
@@ -12,5 +12,11 @@
     "requirements": [
         "aiohttp"
     ],
-    "version": "1.5.1"
+    "version": "1.5.1",
+    "zeroconf": [
+        {
+            "type": "_http._tcp.local.",
+            "name": "hp-bk215*"
+        }
+    ]
 }

--- a/custom_components/sunlit/strings.json
+++ b/custom_components/sunlit/strings.json
@@ -1,6 +1,11 @@
 {
   "config": {
+    "flow_title": "{name}",
     "step": {
+      "zeroconf_confirm": {
+        "title": "Sunlit battery discovered",
+        "description": "A Sunlit BK215 battery (serial {serial_number}) was found on your network. Sunlit reads its data from the Sunlit Solar cloud, so sign in with your Sunlit account on the next screen to set it up."
+      },
       "user": {
         "title": "Sunlit Authentication",
         "description": "Enter your credentials to connect to Sunlit Solar API ({api_url})",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,15 +1,34 @@
 """Test the Sunlit config flow."""
 
+from ipaddress import ip_address
 from unittest.mock import AsyncMock, patch
 
-import pytest
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from custom_components.sunlit import DOMAIN
 from custom_components.sunlit.api_client import SunlitAuthError, SunlitConnectionError
 from custom_components.sunlit.const import CONF_ACCESS_TOKEN, CONF_FAMILIES
+
+
+def _zeroconf_discovery_info(serial: str = "HP-BK215-001") -> ZeroconfServiceInfo:
+    """Build a ZeroconfServiceInfo mimicking a BK215 mDNS advertisement."""
+    return ZeroconfServiceInfo(
+        ip_address=ip_address("192.168.1.50"),
+        ip_addresses=[ip_address("192.168.1.50")],
+        port=80,
+        hostname="hp-bk215-001.local.",
+        type="_http._tcp.local.",
+        name="hp-bk215-001._http._tcp.local.",
+        properties={
+            "id": serial,
+            "port": "80",
+            "fw_ver": "1.2.3",
+            "model": "BK215",
+        },
+    )
 
 
 async def test_form_user_init(hass: HomeAssistant):
@@ -52,7 +71,9 @@ async def test_form_authentication_success(
     ) as mock_client_class:
         mock_client = mock_client_class.return_value
         mock_client.login = AsyncMock(return_value={"access_token": "test_api_key_123"})
-        mock_client.fetch_families = AsyncMock(return_value=families_response["content"])
+        mock_client.fetch_families = AsyncMock(
+            return_value=families_response["content"]
+        )
 
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -91,7 +112,9 @@ async def test_form_family_selection(
     ) as mock_client_class:
         mock_client = mock_client_class.return_value
         mock_client.login = AsyncMock(return_value={"access_token": "test_api_key_123"})
-        mock_client.fetch_families = AsyncMock(return_value=families_response["content"])
+        mock_client.fetch_families = AsyncMock(
+            return_value=families_response["content"]
+        )
 
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -126,7 +149,9 @@ async def test_form_authentication_error(
         "custom_components.sunlit.config_flow.SunlitApiClient",
     ) as mock_client_class:
         mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock(side_effect=SunlitAuthError("Authentication failed"))
+        mock_client.login = AsyncMock(
+            side_effect=SunlitAuthError("Authentication failed")
+        )
 
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -150,7 +175,9 @@ async def test_form_connection_error(
         "custom_components.sunlit.config_flow.SunlitApiClient",
     ) as mock_client_class:
         mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock(side_effect=SunlitConnectionError("Cannot connect"))
+        mock_client.login = AsyncMock(
+            side_effect=SunlitConnectionError("Cannot connect")
+        )
 
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -176,7 +203,9 @@ async def test_form_no_families_selected(
     ) as mock_client_class:
         mock_client = mock_client_class.return_value
         mock_client.login = AsyncMock(return_value={"access_token": "test_api_key_123"})
-        mock_client.fetch_families = AsyncMock(return_value=families_response["content"])
+        mock_client.fetch_families = AsyncMock(
+            return_value=families_response["content"]
+        )
 
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -221,7 +250,9 @@ async def test_form_single_family_auto_select(
     ) as mock_client_class:
         mock_client = mock_client_class.return_value
         mock_client.login = AsyncMock(return_value={"access_token": "test_api_key_123"})
-        mock_client.fetch_families = AsyncMock(return_value=single_family_response["content"])
+        mock_client.fetch_families = AsyncMock(
+            return_value=single_family_response["content"]
+        )
 
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -255,6 +286,90 @@ async def test_form_duplicate_entry(
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_zeroconf_discovery_shows_confirm(hass: HomeAssistant):
+    """A discovered BK215 should present a confirmation step."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=_zeroconf_discovery_info(),
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+    assert result["description_placeholders"]["serial_number"] == "HP-BK215-001"
+
+
+async def test_zeroconf_confirm_proceeds_to_user(hass: HomeAssistant):
+    """Confirming a discovery should funnel into the credential step."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=_zeroconf_discovery_info(),
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "user"
+
+
+async def test_zeroconf_discovery_full_flow(
+    hass: HomeAssistant,
+    families_response,
+):
+    """A discovery should be able to complete the normal cloud setup."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=_zeroconf_discovery_info(),
+    )
+    assert result["step_id"] == "zeroconf_confirm"
+
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result2["step_id"] == "user"
+
+    with patch(
+        "custom_components.sunlit.config_flow.SunlitApiClient",
+    ) as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.login = AsyncMock(return_value={"access_token": "test_api_key_123"})
+        mock_client.fetch_families = AsyncMock(
+            return_value=families_response["content"]
+        )
+
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {"email": "test@example.com", "password": "test_password"},
+        )
+        assert result3["step_id"] == "select_families"
+
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
+            {"families": ["34038"]},
+        )
+
+    assert result4["type"] == FlowResultType.CREATE_ENTRY
+    assert result4["data"][CONF_ACCESS_TOKEN] == "test_api_key_123"
+    assert len(result4["data"][CONF_FAMILIES]) == 1
+
+
+async def test_zeroconf_discovery_already_configured(
+    hass: HomeAssistant,
+    mock_config_entry,
+):
+    """Discovery should abort when the account is already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=_zeroconf_discovery_info(),
     )
 
     assert result["type"] == FlowResultType.ABORT


### PR DESCRIPTION
## What

Adds mDNS/zeroconf discovery so Home Assistant surfaces the BK215 (Highpower) battery on the local network and offers to set up the integration — removing the "where do I find this integration" friction during onboarding.

Inspired by [SunEnergyXT-BK's discovery.py](https://github.com/SunEnergyXT/SunEnergyXT-BK/blob/main/custom_components/sunEnergyXT/discovery.py), but implemented the idiomatic Home Assistant way (manifest matcher + config-flow step) rather than a hand-rolled `AsyncServiceBrowser`.

## Important: discovery is onboarding-only

This integration is **cloud-polling**. The reference integration is *local*-polling and talks to the device directly; we can't do that here. So discovery only acts as a **trigger**: HA detects the battery and shows a "discovered" card, which then funnels the user into the existing email/password + family-selection flow. All runtime data still comes from the Sunlit cloud.

The discovered serial (mDNS TXT `id`) and local host are available in the flow, so a **future opt-in local-polling path** can reuse them — but local polling is explicitly **out of scope** here (it's a longer story: unknown local protocol, dual data-source reconciliation).

## Changes

- **`manifest.json`** — zeroconf matcher: `hp-bk215*` on `_http._tcp.local.`
- **`config_flow.py`** — `async_step_zeroconf` + `async_step_zeroconf_confirm`; dedupes concurrent discovery flows by serial and aborts `already_configured` (single-entry account)
- **`strings.json`** — discovered-card title (`flow_title`) and `zeroconf_confirm` step text
- **`tests/test_config_flow.py`** — 4 new tests: confirm step shown, confirm → credentials, full discovery → entry, already-configured abort

## Testing

- 177 tests pass (4 new)
- `make lint` / `make format` clean; manifest validates via the pre-commit `validate-manifest` hook

## Note for reviewer / hardware check

The mDNS instance name is matched as `hp-bk215*`. If a real BK215 advertises with a prefix before `hp-bk215`, widen to `*hp-bk215*`. Worth confirming against an actual device broadcast.