### PR TITLE
feat(api): migrate base URL to api.sunenergyxt.com and refresh API spec

### DIFF
--- a/custom_components/sunlit/config_flow.py
+++ b/custom_components/sunlit/config_flow.py
@@ -21,6 +21,7 @@ import voluptuous as vol
 
 from .api_client import SunlitApiClient, SunlitAuthError, SunlitConnectionError
 from .const import (
+    API_BASE_URL,
     CONF_ACCESS_TOKEN,
     CONF_EMAIL,
     CONF_FAMILIES,
@@ -127,7 +128,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=schema,
             errors=errors,
-            description_placeholders={"api_url": "https://api.sunlitsolar.de"},
+            description_placeholders={"api_url": API_BASE_URL},
         )
 
     async def async_step_select_families(

--- a/custom_components/sunlit/const.py
+++ b/custom_components/sunlit/const.py
@@ -13,7 +13,10 @@ DEFAULT_NAME = "Sunlit REST Sensor"
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
 
 # API Configuration
-API_BASE_URL = "https://api.sunlitsolar.de/rest"
+# Current backend host used by the SunEnergyXT app (v1.8.1). The legacy
+# api.sunlitsolar.de host still resolves but the app has migrated here; both
+# expose the same /rest API surface (verified 2026-05).
+API_BASE_URL = "https://api.sunenergyxt.com/rest"
 API_USER_LOGIN = "/user/login"
 API_FAMILY_LIST = "/family/list"
 API_DEVICE_DETAILS = "/device/{device_id}"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1225,23 +1225,34 @@ components:
               $ref: "#/components/schemas/BatteryStatistics"
 
     BatteryIOPowerResponse:
-      type: object
-      description: Battery I/O power response (different format - no ApiResponse wrapper)
-      properties:
-        result:
-          type: integer
-          description: Result code (1 = success)
-          example: 1
-        inputPower:
-          type: array
-          items:
-            type: number
-          description: Array of input power values (288 values for 5-minute intervals over 24 hours)
-        outputPower:
-          type: array
-          items:
-            type: number
-          description: Array of output power values (288 values for 5-minute intervals over 24 hours)
+      allOf:
+        - $ref: "#/components/schemas/ApiResponse"
+        - type: object
+          properties:
+            content:
+              type: object
+              properties:
+                powerList:
+                  type: array
+                  description: >-
+                    Intraday battery input/output power samples (~2-minute
+                    cadence; ~400 entries over a full day). Verified live
+                    2026-05 against api.sunenergyxt.com.
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                        description: Sample time (HH:MM)
+                        example: "00:01"
+                      batteryInputPower:
+                        type: number
+                        description: Battery input (charging) power in watts
+                        example: 0.0
+                      batteryOutputPower:
+                        type: number
+                        description: Battery output (discharging) power in watts
+                        example: 32.0
 
     SpaceSOCResponse:
       allOf:
@@ -1409,17 +1420,50 @@ components:
           example: []
 
     StrategyHistoryResponse:
+      allOf:
+        - $ref: "#/components/schemas/ApiResponse"
+        - type: object
+          properties:
+            content:
+              $ref: "#/components/schemas/PaginatedStrategyHistory"
+
+    PaginatedStrategyHistory:
       type: object
-      description: Strategy history response (different format - no ApiResponse wrapper)
+      description: Paginated strategy change history (Spring Data Page shape)
       properties:
-        result:
-          type: integer
-          description: Result code (1 = success)
-          example: 1
-        history:
+        content:
           type: array
           items:
             $ref: "#/components/schemas/StrategyHistoryEntry"
+          description: Strategy history entries for this page
+        pageable:
+          $ref: "#/components/schemas/Pageable"
+        totalPages:
+          type: integer
+          example: 1
+        totalElements:
+          type: integer
+          example: 1
+        last:
+          type: boolean
+          example: true
+        number:
+          type: integer
+          example: 0
+        sort:
+          $ref: "#/components/schemas/Sort"
+        numberOfElements:
+          type: integer
+          example: 1
+        first:
+          type: boolean
+          example: true
+        size:
+          type: integer
+          example: 20
+        empty:
+          type: boolean
+          example: false
 
     ChargingBoxStrategyResponse:
       allOf:
@@ -2661,31 +2705,88 @@ components:
 
     StrategyHistoryEntry:
       type: object
+      description: A single strategy change history entry
       properties:
+        strategyHistoryId:
+          type: integer
+          example: 1748547
         modifyDate:
           type: integer
-          description: Modification timestamp (milliseconds)
-          example: 1609459200000
+          description: Timestamp of the strategy change (milliseconds)
+          example: 1768812894000
         strategy:
           type: string
-          description: Strategy name
-          example: "Time of Use"
-        status:
-          type: string
-          description: Strategy status
-          example: "SUCCESS"
+          description: Strategy type
+          example: "EnergyStorageOnly"
         smartStrategyMode:
-          type: string
-          description: Smart strategy mode
-          example: "AUTO"
-        socMin:
-          type: number
-          description: Minimum SOC setting
-          example: 20
+          type: ["string", "null"]
+          example: null
+        smartStrategyFullMode:
+          type: ["string", "null"]
+          example: null
+        status:
+          type: ["string", "null"]
+          example: "Success"
+        inverterStatus:
+          type: ["string", "null"]
+          example: "Success"
+        modifiedOutPutPower:
+          type: ["number", "null"]
+          description: Modified inverter output power in watts
+          example: 30.0
+        defaultExpectInverterOutput:
+          type: ["number", "null"]
+          example: 30.0
+        batteryStatus:
+          type: ["string", "null"]
+          example: "Success"
         socMax:
-          type: number
-          description: Maximum SOC setting
-          example: 90
+          type: ["integer", "null"]
+          description: Maximum SOC setting at time of change
+          example: 100
+        socMin:
+          type: ["integer", "null"]
+          description: Minimum SOC setting at time of change
+          example: 97
+        powerPercentage:
+          type: ["integer", "null"]
+          example: 1
+        smartStrategyMaxOutputPower:
+          type: ["number", "null"]
+          example: null
+        periodStrategyList:
+          type: array
+          description: Time-period sub-strategies (shape not yet observed)
+          items:
+            type: object
+          example: []
+        priceTag:
+          type: ["string", "null"]
+          example: null
+        executeTimeStart:
+          type: ["string", "null"]
+          description: Execution window start (HH:MM)
+          example: "09:00"
+        executeTimeEnd:
+          type: ["string", "null"]
+          description: Execution window end (HH:MM)
+          example: "10:00"
+        smartStrategyVersion:
+          type: ["string", "null"]
+          example: null
+        gridChargingEnabled:
+          type: ["boolean", "null"]
+          example: false
+        chargingPower:
+          type: ["number", "null"]
+          example: null
+        acCoupleEnabled:
+          type: ["boolean", "null"]
+          example: null
+        isAio:
+          type: ["boolean", "null"]
+          description: Whether the entry applies to an all-in-one (AIO) device
+          example: false
 
     MpptData:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9,25 +9,47 @@ info:
 
     **Note:** This is a reverse-engineered specification based on observed API behavior.
     The actual API is proprietary to Sunlit Solar GmbH.
-  version: 1.0.0
+
+    **Backend host:** The SunEnergyXT app (v1.8.1) now calls `api.sunenergyxt.com`.
+    Requests authenticate with `Authorization: bearer <token>` (lowercase scheme)
+    and the app additionally sends `appVersion`, `language`, `phoneModel`, and
+    `osVersion` headers; these are not required for the documented data endpoints.
+  version: 1.1.0
   contact:
     name: Home Assistant Integration
     url: https://github.com/cedricziel/ha-sunlit
 
 servers:
+  - url: https://api.sunenergyxt.com/rest
+    description: >-
+      Production server. Current backend host used by the SunEnergyXT mobile
+      app (observed in app v1.8.1, May 2026). Shares the same /rest API surface
+      as the legacy host below.
   - url: https://api.sunlitsolar.de/rest
-    description: Production server
+    description: >-
+      Legacy production host still referenced by older integration builds
+      (custom_components/sunlit/const.py::API_BASE_URL).
 
 security:
   - bearerAuth: []
 
 tags:
+  - name: Authentication
+    description: Login and account authentication
   - name: Family
     description: Family/Space management operations
   - name: Device
     description: Device information and statistics
   - name: Space
     description: Space-level operations (SOC, strategies)
+  - name: Statistics
+    description: Energy, power, and earnings statistics
+  - name: Strategy
+    description: Battery charging strategies and local mode configuration
+  - name: User
+    description: User account information
+  - name: System
+    description: Backend health and app lifecycle endpoints
 
 paths:
   /family/list:
@@ -686,7 +708,11 @@ paths:
       tags:
         - Device
       summary: Get device details
-      description: Retrieve detailed information about a specific device (currently unused in integration)
+      description: |
+        Retrieve detailed information about a specific device, including
+        firmware/hardware versions, BMS/SBMS SOC limits, local-mode flags, and
+        the device's local network address (ip/port). Returns the standard
+        `{code, message, content}` envelope.
       operationId: getDeviceDetails
       parameters:
         - name: deviceId
@@ -706,6 +732,338 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           description: Device not found
+
+  /user/info:
+    post:
+      tags:
+        - User
+      summary: Get current user info
+      description: Retrieve the authenticated user's account profile.
+      operationId: getUserInfo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Empty object
+              example: {}
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserInfoResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /v1.1/space/statistics/static:
+    post:
+      tags:
+        - Statistics
+      summary: Get lifetime space statistics
+      description: Retrieve cumulative yield and earnings for a space.
+      operationId: getSpaceStatisticsStatic
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - spaceId
+              properties:
+                spaceId:
+                  type: integer
+                  description: The space/family ID
+                  example: 34038
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpaceStatisticsStaticResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /v1.1/space/statistics/dynamic/power:
+    post:
+      tags:
+        - Statistics
+      summary: Get intraday space power curve
+      description: |
+        Retrieve the power generation curve for a space on a given day. Returns
+        a list of timestamped power samples (roughly every 2 minutes).
+      operationId: getSpaceStatisticsDynamicPower
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - spaceId
+                - year
+                - month
+                - day
+              properties:
+                spaceId:
+                  type: integer
+                  example: 34038
+                year:
+                  type: integer
+                  example: 2026
+                month:
+                  type: integer
+                  description: Month (1-12, not zero-padded)
+                  example: 5
+                day:
+                  type: integer
+                  example: 24
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpaceStatisticsDynamicPowerResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /v1.1/space/statistics/dynamic/earning:
+    post:
+      tags:
+        - Statistics
+      summary: Get monthly space earnings breakdown
+      description: |
+        Retrieve per-day power generation and earnings for a space over a month,
+        plus per-day charging energy.
+      operationId: getSpaceStatisticsDynamicEarning
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - spaceId
+                - year
+                - month
+              properties:
+                spaceId:
+                  type: integer
+                  example: 34038
+                year:
+                  type: integer
+                  example: 2026
+                month:
+                  type: integer
+                  description: Month (1-12, not zero-padded)
+                  example: 5
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SpaceStatisticsDynamicEarningResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /statistics/instantPower:
+    post:
+      tags:
+        - Statistics
+      summary: Get intraday device power curve
+      description: |
+        Retrieve the instantaneous power curve for a single device on a given
+        day. Distinct from `/v1.3/statistics/instantPower/batteryIO`: this
+        endpoint is unversioned, takes a `deviceId`, and returns the standard
+        envelope with a `powerList` of `{key, power}` samples.
+      operationId: getInstantPower
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - deviceId
+                - year
+                - month
+                - day
+              properties:
+                deviceId:
+                  type: integer
+                  example: 41714
+                year:
+                  type: string
+                  description: Year (YYYY)
+                  example: "2026"
+                month:
+                  type: string
+                  description: Month (MM, zero-padded)
+                  example: "05"
+                day:
+                  type: string
+                  description: Day (DD, zero-padded)
+                  example: "24"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InstantPowerResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /v1.8/strategy/my/list:
+    post:
+      tags:
+        - Strategy
+      summary: List configured strategies
+      description: |
+        Retrieve the user-configured charging strategies for a space. Replaces
+        the older `/v1.1/space/currentStrategy` + `/v1.1/space/strategyHistory`
+        pair in newer app versions.
+      operationId: getStrategyMyList
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - spaceId
+              properties:
+                spaceId:
+                  type: integer
+                  example: 34038
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StrategyMyListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /v1.7/strategy/device/status:
+    post:
+      tags:
+        - Strategy
+      summary: Get device strategy/local-mode status
+      description: |
+        Retrieve the local-mode and UPS-mode status for the strategy-capable
+        device(s) in a space.
+      operationId: getStrategyDeviceStatus
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - spaceId
+              properties:
+                spaceId:
+                  type: integer
+                  example: 34038
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StrategyDeviceStatusResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /v1.7/battery/updateLocalModeConfig:
+    post:
+      tags:
+        - Strategy
+      summary: Enable/disable battery local mode
+      description: |
+        Toggle local mode for a battery. Local mode lets the battery operate
+        from on-device logic (see `/device/{deviceId}` ip/port) rather than
+        cloud strategy. Returns `content: null` on success.
+      operationId: updateBatteryLocalModeConfig
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - enable
+                - deviceSn
+              properties:
+                enable:
+                  type: boolean
+                  description: Whether to enable local mode
+                  example: false
+                deviceSn:
+                  type: string
+                  description: Battery serial number
+                  example: "dcbdccbffe3d"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BatteryLocalModeUpdateResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /v1.5/message/summary:
+    post:
+      tags:
+        - System
+      summary: Get notification/message counts
+      description: Retrieve unread message, fault, and notification counts.
+      operationId: getMessageSummary
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Empty object
+              example: {}
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MessageSummaryResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /health/status:
+    get:
+      tags:
+        - System
+      summary: Backend health status
+      description: |
+        Diagnostic backend health probe. Reports the status of dependent
+        services (RabbitMQ, Redis, disk). Not account-scoped data.
+      operationId: getHealthStatus
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthStatusResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
 components:
   securitySchemes:
@@ -1750,6 +2108,10 @@ components:
           type: integer
           description: Last update timestamp
           example: 1757165899155
+        deviceModel:
+          type: ["string", "null"]
+          description: Battery model identifier
+          example: "BK_215"
 
     ChargingBoxStatus:
       type: object
@@ -1812,7 +2174,7 @@ components:
 
     EVChargerStatus:
       type: object
-      description: EV charger status
+      description: EV charger status (spaceChargePileDTO)
       properties:
         deviceSns:
           type: array
@@ -1824,6 +2186,19 @@ components:
           type: string
           description: Device type
           example: "STAR_CHARGE_EVSE"
+        deviceStatus:
+          type: string
+          enum: [Online, Offline, NotExist]
+          description: Device status
+          example: "NotExist"
+        fault:
+          type: boolean
+          description: Fault status
+          example: false
+        evseStatus:
+          type: ["string", "null"]
+          description: EVSE charging status
+          example: null
 
     LoginRequest:
       type: object
@@ -1889,30 +2264,168 @@ components:
                   type: ["string", "null"]
                   description: User profile picture URL
                   example: null
-          deviceStatus:
-            type: string
-            enum: [Online, Offline, NotExist]
-            description: Device status
-            example: "NotExist"
-          fault:
-            type: boolean
-            description: Fault status
-            example: false
-          evseStatus:
-            type: ["string", "null"]
-            description: EVSE status
-            example: null
 
     DeviceDetailsResponse:
+      allOf:
+        - $ref: "#/components/schemas/ApiResponse"
+        - type: object
+          properties:
+            content:
+              $ref: "#/components/schemas/DeviceDetailContent"
+
+    DeviceDetailContent:
       type: object
-      description: Device details response (different format - no ApiResponse wrapper)
+      description: Detailed device information from GET /device/{deviceId}
       properties:
-        result:
+        deviceId:
           type: integer
-          description: Result code (1 = success)
-          example: 1
-        device:
-          $ref: "#/components/schemas/Device"
+          example: 41714
+        deviceSn:
+          type: string
+          example: "dcbdccbffe3d"
+        createDate:
+          type: integer
+          description: Device registration timestamp (milliseconds)
+          example: 1727164484000
+        firmwareVersion:
+          type: ["string", "null"]
+          example: "V1.5.8"
+        familyItem:
+          type: object
+          description: The family/space this device belongs to
+          properties:
+            id:
+              type: integer
+              example: 34038
+            name:
+              type: string
+              example: "Garage"
+        status:
+          type: string
+          enum: [Online, Offline, NotExist]
+          example: "Online"
+        manufacturer:
+          type: ["string", "null"]
+          example: "Highpower"
+        deviceType:
+          type: string
+          example: "ENERGY_STORAGE_BATTERY"
+        ssid:
+          type: ["string", "null"]
+          description: WiFi SSID the device is connected to
+          example: "WLAN-2TXFBD"
+        stationName:
+          type: ["string", "null"]
+          example: null
+        collectorSn:
+          type: ["string", "null"]
+          example: null
+        maxOutputPower:
+          type: ["number", "null"]
+          example: null
+        maxAllowedPower:
+          type: ["number", "null"]
+          example: null
+        ratedPower:
+          type: ["number", "null"]
+          example: null
+        xmChannel:
+          type: ["boolean", "null"]
+          description: Whether the Xiaomi/XM control channel is available
+          example: true
+        subStatus:
+          type: ["string", "null"]
+          example: null
+        collectorFirmwareVersion:
+          type: ["string", "null"]
+          example: null
+        wifiFirmwareVersion:
+          type: ["string", "null"]
+          example: null
+        acFirmwareVersion:
+          type: ["string", "null"]
+          example: null
+        dcFirmwareVersion:
+          type: ["string", "null"]
+          example: null
+        hwVersion:
+          type: ["string", "null"]
+          example: "V1.5"
+        batteryChargingBoxDto:
+          type: ["object", "null"]
+          example: null
+        batteryBoxStatus:
+          type: ["string", "null"]
+          enum: [Online, Offline, NotExist, null]
+          example: "NotExist"
+        supportReboot:
+          type: ["boolean", "null"]
+          description: Whether the device supports remote reboot
+          example: true
+        systemMultiStatus:
+          type: ["string", "null"]
+          description: Localized multi-battery topology description
+          example: "Drei Batterien parallel"
+        enableNotFullNotification:
+          type: ["boolean", "null"]
+          example: true
+        deviceModel:
+          type: ["string", "null"]
+          example: "BK_215"
+        hwSupportOnePercentage:
+          type: ["boolean", "null"]
+          description: Whether hardware supports 1% SOC granularity
+          example: true
+        hwSbmsLimitedDiscSocMin:
+          type: ["number", "null"]
+          description: Hardware SBMS discharge minimum SOC
+          example: 1.0
+        hwSbmsLimitedChgSocMax:
+          type: ["number", "null"]
+          description: Hardware SBMS charge maximum SOC
+          example: 100.0
+        batteryBmsDiscSocMin:
+          type: ["integer", "null"]
+          description: Battery BMS discharge minimum SOC
+          example: 10
+        batteryBmsChgSocMax:
+          type: ["integer", "null"]
+          description: Battery BMS charge maximum SOC
+          example: 100
+        hasInverter:
+          type: ["boolean", "null"]
+          example: false
+        supportLocalMode:
+          type: ["boolean", "null"]
+          description: Whether the device supports local (on-device) mode
+          example: true
+        localModeEnabled:
+          type: ["boolean", "null"]
+          description: Whether local mode is currently enabled
+          example: true
+        ip:
+          type: ["string", "null"]
+          description: Local network IP address of the device
+          example: "192.168.1.79"
+        port:
+          type: ["string", "null"]
+          description: Local control port of the device
+          example: "8000"
+        otaInProgress:
+          type: ["boolean", "null"]
+          example: false
+        hasValidMeter:
+          type: ["boolean", "null"]
+          example: false
+        upsModeEnabled:
+          type: ["boolean", "null"]
+          example: false
+        hasFault:
+          type: ["boolean", "null"]
+          example: false
+        evRunningNotice:
+          type: ["boolean", "null"]
+          example: false
 
     Family:
       type: object
@@ -1961,6 +2474,24 @@ components:
           type: ["string", "null"]
           description: Rabot customer identifier
           example: null
+        spaceType:
+          type: ["string", "null"]
+          description: Space type classification
+          example: null
+        evStrategyEnabled:
+          type: boolean
+          description: Whether an EV charging strategy is enabled for this space
+          example: false
+        tarrifStrategyEnabled:
+          type: boolean
+          description: >-
+            Whether a tariff-based strategy is enabled (note: the API spells
+            this field "tarrif").
+          example: false
+        remindWhileBoostOn:
+          type: boolean
+          description: Whether to notify the user while boost mode is active
+          example: false
 
     Device:
       type: object
@@ -2176,6 +2707,10 @@ components:
           type: string
           description: MPPT identifier
           example: "MPPT1"
+        deviceModel:
+          type: ["string", "null"]
+          description: Model of the unit this MPPT belongs to (e.g. BK_215, B_215)
+          example: "BK_215"
 
     BatteryStatistics:
       type: object
@@ -2201,6 +2736,10 @@ components:
           type: string
           description: Device type
           example: "ENERGY_STORAGE_BATTERY"
+        deviceModel:
+          type: ["string", "null"]
+          description: Battery model identifier
+          example: "BK_215"
         batterySoc:
           type: ["number", "null"]
           description: System battery SOC
@@ -2216,6 +2755,50 @@ components:
         battery3Soc:
           type: ["number", "null"]
           description: Battery module 3 SOC
+          example: null
+        battery4Soc:
+          type: ["number", "null"]
+          description: Battery module 4 SOC
+          example: null
+        battery5Soc:
+          type: ["number", "null"]
+          description: Battery module 5 SOC
+          example: null
+        battery6Soc:
+          type: ["number", "null"]
+          description: Battery module 6 SOC
+          example: null
+        battery7Soc:
+          type: ["number", "null"]
+          description: Battery module 7 SOC
+          example: null
+        battery1DeviceModel:
+          type: ["string", "null"]
+          description: Model of battery module 1
+          example: "B_215"
+        battery2DeviceModel:
+          type: ["string", "null"]
+          description: Model of battery module 2
+          example: "B_215"
+        battery3DeviceModel:
+          type: ["string", "null"]
+          description: Model of battery module 3
+          example: null
+        battery4DeviceModel:
+          type: ["string", "null"]
+          description: Model of battery module 4
+          example: null
+        battery5DeviceModel:
+          type: ["string", "null"]
+          description: Model of battery module 5
+          example: null
+        battery6DeviceModel:
+          type: ["string", "null"]
+          description: Model of battery module 6
+          example: null
+        battery7DeviceModel:
+          type: ["string", "null"]
+          description: Model of battery module 7
           example: null
         chargeRemaining:
           type: ["number", "null"]
@@ -2300,6 +2883,26 @@ components:
             - $ref: "#/components/schemas/MpptData"
             - type: "null"
           description: Battery module 3 MPPT data
+        battery4MpptData:
+          oneOf:
+            - $ref: "#/components/schemas/MpptData"
+            - type: "null"
+          description: Battery module 4 MPPT data
+        battery5MpptData:
+          oneOf:
+            - $ref: "#/components/schemas/MpptData"
+            - type: "null"
+          description: Battery module 5 MPPT data
+        battery6MpptData:
+          oneOf:
+            - $ref: "#/components/schemas/MpptData"
+            - type: "null"
+          description: Battery module 6 MPPT data
+        battery7MpptData:
+          oneOf:
+            - $ref: "#/components/schemas/MpptData"
+            - type: "null"
+          description: Battery module 7 MPPT data
         mpptCollectTime:
           type: ["integer", "null"]
           description: MPPT data collection timestamp
@@ -2372,3 +2975,260 @@ components:
           type: ["number", "null"]
           description: Battery level percentage
           example: 15.0
+
+    UserInfoResponse:
+      allOf:
+        - $ref: "#/components/schemas/ApiResponse"
+        - type: object
+          properties:
+            content:
+              type: object
+              description: Authenticated user's profile
+              properties:
+                email:
+                  type: string
+                  example: "user@example.com"
+                nickName:
+                  type: string
+                  example: "username"
+                headPicUrl:
+                  type: ["string", "null"]
+                  example: null
+
+    SpaceStatisticsStaticResponse:
+      allOf:
+        - $ref: "#/components/schemas/ApiResponse"
+        - type: object
+          properties:
+            content:
+              type: object
+              description: Lifetime yield and earnings for a space
+              properties:
+                spaceId:
+                  type: integer
+                  example: 34038
+                totalYield:
+                  type: number
+                  description: Lifetime energy yield in kWh
+                  example: 1547.04
+                totalEarnings:
+                  $ref: "#/components/schemas/MonetaryAmount"
+
+    SpaceStatisticsDynamicPowerResponse:
+      allOf:
+        - $ref: "#/components/schemas/ApiResponse"
+        - type: object
+          properties:
+            content:
+              type: object
+              properties:
+                spaceId:
+                  type: integer
+                  example: 34038
+                powerList:
+                  type: array
+                  description: Intraday power samples
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                        description: Sample time (HH:MM)
+                        example: "00:01"
+                      power:
+                        type: number
+                        description: Generated power in watts
+                        example: 0.0
+                      homePower:
+                        type: ["number", "null"]
+                        description: Home consumption in watts (null if no meter)
+                        example: null
+
+    SpaceStatisticsDynamicEarningResponse:
+      allOf:
+        - $ref: "#/components/schemas/ApiResponse"
+        - type: object
+          properties:
+            content:
+              type: object
+              properties:
+                totalPowerGeneration:
+                  type: number
+                  description: Total generation for the month in kWh
+                  example: 29.343
+                totalEarnings:
+                  $ref: "#/components/schemas/MonetaryAmount"
+                powerEarningsList:
+                  type: array
+                  description: Per-day generation and earnings
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        type: integer
+                        description: Day of month
+                        example: 1
+                      totalPowerGeneration:
+                        type: number
+                        example: 1.231
+                      totalEarnings:
+                        type: number
+                        example: 0.3693
+                      currency:
+                        type: string
+                        example: "EUR"
+                chargingEnergyList:
+                  type: array
+                  description: Per-day charging energy
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        type: integer
+                        description: Day of month
+                        example: 1
+                      chargingEnergy:
+                        type: number
+                        example: 0
+
+    InstantPowerResponse:
+      allOf:
+        - $ref: "#/components/schemas/ApiResponse"
+        - type: object
+          properties:
+            content:
+              type: object
+              properties:
+                powerList:
+                  type: array
+                  description: Intraday instantaneous power samples for a device
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                        description: Sample time (HH:MM)
+                        example: "00:01"
+                      power:
+                        type: number
+                        description: Power in watts
+                        example: 97.0
+
+    StrategyMyListResponse:
+      allOf:
+        - $ref: "#/components/schemas/ApiResponse"
+        - type: object
+          properties:
+            content:
+              type: object
+              properties:
+                strategyList:
+                  type: array
+                  description: >-
+                    User-configured strategies. Empty when no custom strategy is
+                    set; item shape not yet observed.
+                  items:
+                    type: object
+                  example: []
+
+    StrategyDeviceStatusResponse:
+      allOf:
+        - $ref: "#/components/schemas/ApiResponse"
+        - type: object
+          properties:
+            content:
+              type: object
+              description: Local-mode/UPS status for the strategy-capable device
+              properties:
+                batteryLocalModeEnabled:
+                  type: boolean
+                  example: true
+                aioLocalModeEnabled:
+                  type: boolean
+                  description: All-in-one (AIO) device local mode enabled
+                  example: false
+                aioUpsEnabled:
+                  type: boolean
+                  example: false
+                deviceModel:
+                  type: string
+                  example: "BK_215"
+
+    BatteryLocalModeUpdateResponse:
+      allOf:
+        - $ref: "#/components/schemas/ApiResponse"
+        - type: object
+          properties:
+            content:
+              type: "null"
+              description: No content returned on successful update
+              example: null
+
+    MessageSummaryResponse:
+      allOf:
+        - $ref: "#/components/schemas/ApiResponse"
+        - type: object
+          properties:
+            content:
+              type: object
+              properties:
+                unReadCount:
+                  type: integer
+                  example: 0
+                faultUnReadCount:
+                  type: integer
+                  example: 0
+                notificationUnReadCount:
+                  type: integer
+                  example: 8
+
+    HealthStatusResponse:
+      allOf:
+        - $ref: "#/components/schemas/ApiResponse"
+        - type: object
+          properties:
+            content:
+              type: object
+              description: Backend service health snapshot
+              properties:
+                status:
+                  type: string
+                  example: "OK"
+                rabbitHealth:
+                  $ref: "#/components/schemas/HealthComponent"
+                redisHealth:
+                  $ref: "#/components/schemas/HealthComponent"
+                mysqlHealth:
+                  oneOf:
+                    - $ref: "#/components/schemas/HealthComponent"
+                    - type: "null"
+                mongoHealth:
+                  oneOf:
+                    - $ref: "#/components/schemas/HealthComponent"
+                    - type: "null"
+                diskSpaceHealth:
+                  $ref: "#/components/schemas/HealthComponent"
+
+    HealthComponent:
+      type: object
+      description: Health state of a single backend dependency
+      properties:
+        status:
+          type: string
+          example: "UP"
+        details:
+          type: object
+          additionalProperties: true
+          example:
+            version: "7.0.15"
+
+    MonetaryAmount:
+      type: object
+      description: A monetary amount with currency
+      properties:
+        earnings:
+          type: number
+          example: 473.38
+        currency:
+          type: string
+          example: "EUR"

--- a/scripts/verify-api.sh
+++ b/scripts/verify-api.sh
@@ -11,6 +11,11 @@
 #      (decides whether "aggregate across families" can find unassigned devices)
 #   5. Is the error `message` field a localized dict ({"DE": ...})?
 #
+# It then probes a broad set of read-only endpoints documented in openapi.yaml
+# (account, space, strategy, statistics, device) and reports each one's `code`
+# plus a one-line shape of `content`, so drift between the spec and the live API
+# is easy to spot. Write/control endpoints are listed but never called.
+#
 # Usage:
 #   Auth with credentials (logs in, prints nothing secret):
 #     SUNLIT_EMAIL=you@example.com SUNLIT_PASSWORD=secret ./scripts/verify-api.sh
@@ -18,7 +23,8 @@
 #     SUNLIT_TOKEN=eyJ... ./scripts/verify-api.sh
 #
 # Optional:
-#   SUNLIT_BASE_URL  override API base (default: https://api.sunlitsolar.de/rest)
+#   SUNLIT_BASE_URL  override API base (default: https://api.sunlitsolar.de/rest;
+#                    the SunEnergyXT app v1.8.1 uses https://api.sunenergyxt.com/rest)
 
 set -uo pipefail
 
@@ -76,6 +82,33 @@ http_of() { tail -n1 <<<"$1"; }
 body_of() { sed '$d' <<<"$1"; }
 code_of() { jq -r '.code // "?"' <<<"$1" 2>/dev/null; }
 msg_of()  { jq -rc '.message // ""' <<<"$1" 2>/dev/null; }
+
+# probe METHOD PATH BODY DESC
+# Calls an endpoint and reports code 0 + a one-line `content` shape, or the
+# failing HTTP/code/message. Pass BODY="" for GET / bodyless requests; pass a
+# literal '{}' to send an empty JSON object.
+probe() {
+  local method="$1" path="$2" body="$3" desc="$4"
+  local resp jb http code summary
+  if [[ -n "$body" ]]; then
+    resp=$(request "$method" "$path" "$body")
+  else
+    resp=$(request "$method" "$path")
+  fi
+  jb=$(body_of "$resp"); http=$(http_of "$resp"); code=$(code_of "$jb")
+  [[ -z "$code" ]] && code="?"
+  if [[ "$code" == "0" ]]; then
+    summary=$(jq -rc '
+      .content as $c |
+      if   ($c|type)=="array"  then "array[\($c|length)]"
+      elif ($c|type)=="object" then "{\($c|keys|length) keys: \($c|keys|.[0:6]|join(", "))\(if ($c|keys|length)>6 then ", …" else "" end)}"
+      elif $c==null            then "null"
+      else ($c|tostring) end' <<<"$jb" 2>/dev/null)
+    pass "$desc  [content: ${summary:-?}]"
+  else
+    fail "$desc — HTTP $http, code $code, msg $(msg_of "$jb")"
+  fi
+}
 
 # ---- authenticate ----------------------------------------------------------
 section "Auth"
@@ -185,3 +218,61 @@ else
   echo "    'unassigned devices' feature cannot work via this endpoint →"
   echo "    favor removing it / silencing the bodyless call."
 fi
+
+# ---- broad read-only endpoint coverage (from openapi.yaml) ------------------
+# Probes a representative set of documented read endpoints and prints code +
+# a one-line `content` shape. Uses the first family ($FID) as spaceId/familyId
+# (they share the same numeric id in this API) and the first device for
+# device-scoped calls. WRITE/control endpoints are listed but NOT called.
+section "Spec endpoint coverage (read-only) — space/family $FID"
+
+YEAR=$(date +%Y); MONTH=$(date +%m); DAY=$(date +%d)
+MONTH_INT=$((10#$MONTH)); DAY_INT=$((10#$DAY))   # 10# avoids octal on 08/09
+TODAY="$YEAR-$MONTH-$DAY"
+FIRST_DEVICE_ID=$(jq -r '.content.content[0].deviceId // empty' <<<"${abody:-}" 2>/dev/null)
+sid=$(jq -nc --argjson f "$FID" '{spaceId:$f}')
+fidbody=$(jq -nc --argjson f "$FID" '{familyId:$f}')
+
+note "account / system"
+probe POST /user/info            '{}' "POST /user/info"
+probe POST /v1.5/message/summary '{}' "POST /v1.5/message/summary"
+probe GET  /health/status        ''   "GET  /health/status"
+
+note "space-level"
+probe POST /v1.5/space/index                    "$sid" "POST /v1.5/space/index"
+probe POST /v1.1/space/soc                       "$sid" "POST /v1.1/space/soc"
+probe POST /v1.6/tariff/index                    "$sid" "POST /v1.6/tariff/index"
+probe POST /v1.6/chargingBox/checkSpaceStrategy  "$sid" "POST /v1.6/chargingBox/checkSpaceStrategy"
+probe POST /v1.6/rabot/state                     "$sid" "POST /v1.6/rabot/state"
+probe POST /v1.6/rabot/day/price "$(jq -nc --argjson f "$FID" --arg d "$TODAY" '{showTax:true,spaceId:$f,day:$d,showStrategy:false}')" "POST /v1.6/rabot/day/price"
+probe POST /v1.6/space/local/infoV2              "$sid" "POST /v1.6/space/local/infoV2"
+
+note "strategy"
+probe POST /v1.8/strategy/my/list       "$sid"     "POST /v1.8/strategy/my/list"
+probe POST /v1.7/strategy/device/status "$sid"     "POST /v1.7/strategy/device/status"
+probe POST /v1.1/space/currentStrategy  "$fidbody" "POST /v1.1/space/currentStrategy  (legacy)"
+probe POST /v1.1/space/strategyHistory  "$fidbody" "POST /v1.1/space/strategyHistory  (legacy)"
+
+note "statistics (space-scoped)"
+probe POST /v1.1/space/statistics/static          "$sid" "POST /v1.1/space/statistics/static"
+probe POST /v1.1/space/statistics/dynamic/power    "$(jq -nc --argjson f "$FID" --argjson y "$YEAR" --argjson m "$MONTH_INT" --argjson d "$DAY_INT" '{spaceId:$f,year:$y,month:$m,day:$d}')" "POST /v1.1/space/statistics/dynamic/power"
+probe POST /v1.1/space/statistics/dynamic/earning  "$(jq -nc --argjson f "$FID" --argjson y "$YEAR" --argjson m "$MONTH_INT" '{spaceId:$f,year:$y,month:$m}')" "POST /v1.1/space/statistics/dynamic/earning"
+
+note "device-scoped"
+if [[ -n "$FIRST_DEVICE_ID" ]]; then
+  note "using deviceId=$FIRST_DEVICE_ID"
+  probe GET  "/device/$FIRST_DEVICE_ID"      ''  "GET  /device/{deviceId}"
+  probe POST /v1.1/statistics/static/device  "$(jq -nc --argjson d "$FIRST_DEVICE_ID" '{deviceId:$d}')" "POST /v1.1/statistics/static/device"
+  probe POST /statistics/instantPower        "$(jq -nc --argjson d "$FIRST_DEVICE_ID" --arg y "$YEAR" --arg m "$MONTH" --arg da "$DAY" '{deviceId:$d,year:$y,month:$m,day:$da}')" "POST /statistics/instantPower"
+  probe POST /v1.3/statistics/instantPower/batteryIO "$(jq -nc --argjson d "$FIRST_DEVICE_ID" --arg y "$YEAR" --arg m "$MONTH" --arg da "$DAY" '{deviceId:$d,year:$y,month:$m,day:$da}')" "POST /v1.3/statistics/instantPower/batteryIO"
+else
+  note "no devices in family $FID — skipping device-scoped probes"
+fi
+
+section "Write/control endpoints (NOT called — reference only)"
+note "POST /v1.7/battery/updateLocalModeConfig          {enable, deviceSn}"
+note "POST /v2/remoteControl/power                      {deviceId, maxOutputPower}"
+note "POST /device/remoteControlRecord/latest           {deviceId}"
+note "POST /v1.6/tariffStrategy/add                     {familyId, lowPriceStrategy, highPriceStrategy, …}"
+note "POST /v1.6/local/mode/deye/localSmart/updateFlag  {spaceId, enable, inverterSnList}"
+note "POST /v1.7/device/dtu/checkFwVersion              {curFirmwareVersion}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,8 +43,10 @@ def mock_config_entry():
 
 @pytest.fixture
 def api_base_url():
-    """Return the API base URL for mocking."""
-    return "https://api.sunlitsolar.de/rest"
+    """Return the API base URL for mocking (tracks const.API_BASE_URL)."""
+    from custom_components.sunlit.const import API_BASE_URL
+
+    return API_BASE_URL
 
 
 # API Response Fixtures

--- a/tests/conftest_simple.py
+++ b/tests/conftest_simple.py
@@ -11,5 +11,7 @@ import pytest
 
 @pytest.fixture
 def api_base_url():
-    """Return the API base URL for mocking."""
-    return "https://api.sunlitsolar.de/rest"
+    """Return the API base URL for mocking (tracks const.API_BASE_URL)."""
+    from custom_components.sunlit.const import API_BASE_URL
+
+    return API_BASE_URL

--- a/tests/test_simple_api_client.py
+++ b/tests/test_simple_api_client.py
@@ -8,6 +8,7 @@ import pytest
 from aioresponses import aioresponses
 
 from custom_components.sunlit.api_client import SunlitApiClient
+from custom_components.sunlit.const import API_BASE_URL
 
 
 @pytest.mark.asyncio
@@ -16,7 +17,7 @@ async def test_get_families():
     with aioresponses() as m:
         # Mock the API response
         m.get(
-            "https://api.sunlitsolar.de/rest/family/list",
+            f"{API_BASE_URL}/family/list",
             payload={
                 "code": 0,
                 "content": [
@@ -43,7 +44,7 @@ async def test_fetch_space_index():
     with aioresponses() as m:
         # Mock the API response
         m.post(
-            "https://api.sunlitsolar.de/rest/v1.5/space/index",
+            f"{API_BASE_URL}/v1.5/space/index",
             payload={
                 "code": 0,
                 "content": {
@@ -71,7 +72,7 @@ async def test_error_handling():
     with aioresponses() as m:
         # Mock an error response
         m.get(
-            "https://api.sunlitsolar.de/rest/family/list",
+            f"{API_BASE_URL}/family/list",
             payload={"code": 1, "message": {"DE": "Error"}, "content": None},
         )
 


### PR DESCRIPTION
## Summary

The SunEnergyXT app (v1.8.1) has migrated its backend to
`api.sunenergyxt.com`. This PR points the integration at the new host and
brings the (hand-maintained) API reference + verification tooling back in
line with the live API, based on a fresh capture of real app traffic.

## What changed

- **`feat(api)`** — `API_BASE_URL` → `https://api.sunenergyxt.com/rest`.
  The setup-flow placeholder and tests now derive from `API_BASE_URL`
  (single source of truth) instead of a hardcoded host.
- **`docs(api)`** — Refreshed `openapi.yaml` from captured traffic: new
  primary server, 10 newly-documented endpoints (user/info, space
  statistics, instantPower, strategy/my/list, strategy/device/status,
  battery local-mode, message/summary, health), and field additions
  (Family flags, per-slot `deviceModel`, battery modules 4–7).
- **`docs(api)`** — Corrected two stale schemas verified against the live
  API: `BatteryIOPowerResponse` (envelope + `content.powerList`) and
  `StrategyHistoryResponse` (paginated). The integration code already
  parsed these correctly — only the spec had drifted.
- **`chore(scripts)`** — `verify-api.sh` now probes ~20 documented
  read-only endpoints and reports each one's `code` + content shape, so
  spec/live drift is easy to spot. Write/control endpoints are listed but
  never called. Stays bash 3.2-compatible.

## Migration safety (no forced re-auth)

Validated that **bearer tokens are interchangeable between both hosts**:

- The JWT is `HS256`-signed with **no `iss`/`aud`/host binding**.
- The same token returns live data (`HTTP 200`, `code 0`) from **both**
  `api.sunenergyxt.com` and `api.sunlitsolar.de`.

So existing installs keep working without re-authentication. The legacy
host still resolves, making the switch reversible.

## Test plan

- [x] `openapi.yaml` parses (OpenAPI 3.1.0) with all `$ref`s resolved.
- [x] Edited Python files compile; pre-commit (ruff/ruff-format/isort)
      passes.
- [x] `verify-api.sh` run live against `api.sunenergyxt.com`: all
      read-only endpoint probes return `code 0`.
- [ ] CI (`pytest`) — could not run locally (no HA test harness here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)