### PR TITLE
feat(sensors): add lifetime yield & earnings (#155)

### DIFF
--- a/custom_components/sunlit/api_client.py
+++ b/custom_components/sunlit/api_client.py
@@ -19,6 +19,7 @@ from .const import (
     API_SPACE_CURRENT_STRATEGY,
     API_SPACE_INDEX,
     API_SPACE_SOC,
+    API_SPACE_STATISTICS_STATIC,
     API_SPACE_STRATEGY_HISTORY,
     API_USER_LOGIN,
 )
@@ -529,6 +530,45 @@ class SunlitApiClient:
         except SunlitApiError as err:
             _LOGGER.error(
                 "Failed to fetch SOC configuration for space %s: %s", space_id, err
+            )
+            raise
+
+    async def fetch_space_statistics_static(
+        self, space_id: str | int
+    ) -> dict[str, Any]:
+        """Fetch lifetime yield and earnings totals for a space/family.
+
+        Args:
+            space_id: The space/family ID to fetch lifetime statistics for
+
+        Returns:
+            Dictionary containing cumulative totals:
+            - totalYield: Lifetime energy yield in kWh
+            - totalEarnings: {earnings, currency}
+
+        Raises:
+            SunlitAuthError: Authentication failed
+            SunlitConnectionError: Connection failed
+            SunlitApiError: API returned an error
+        """
+        try:
+            payload = {"spaceId": int(space_id)}
+            response = await self._make_request(
+                "POST", API_SPACE_STATISTICS_STATIC, json=payload
+            )
+
+            _LOGGER.debug(
+                "Space static statistics response for %s: %s", space_id, response
+            )
+
+            if "content" in response:
+                return response["content"]
+
+            return {}
+
+        except SunlitApiError as err:
+            _LOGGER.error(
+                "Failed to fetch lifetime statistics for space %s: %s", space_id, err
             )
             raise
 

--- a/custom_components/sunlit/const.py
+++ b/custom_components/sunlit/const.py
@@ -27,6 +27,7 @@ API_SPACE_SOC = "/v1.1/space/soc"
 API_SPACE_CURRENT_STRATEGY = "/v1.1/space/currentStrategy"
 API_SPACE_STRATEGY_HISTORY = "/v1.1/space/strategyHistory"
 API_SPACE_INDEX = "/v1.5/space/index"
+API_SPACE_STATISTICS_STATIC = "/v1.1/space/statistics/static"
 API_CHARGING_BOX_CHECK_STRATEGY = "/v1.6/chargingBox/checkSpaceStrategy"
 
 # Configuration keys
@@ -167,6 +168,9 @@ FAMILY_SENSORS = {
     "daily_earnings": "Daily Earnings",
     "home_power": "Home Power",
     "currency": "Currency",
+    # Lifetime totals from space/statistics/static endpoint
+    "lifetime_yield": "Lifetime Yield",
+    "lifetime_earnings": "Lifetime Earnings",
     # Total solar production tracking
     "total_solar_energy": "Total Solar Energy",
     "total_solar_power": "Total Solar Power",
@@ -212,6 +216,7 @@ SENSOR_GROUPS = {
     "online_devices": SENSOR_GROUP_OVERVIEW,
     # Group 2: Energy Production & Storage - Energy Dashboard compatible
     "daily_yield": SENSOR_GROUP_ENERGY,
+    "lifetime_yield": SENSOR_GROUP_ENERGY,
     "total_solar_energy": SENSOR_GROUP_ENERGY,
     "total_grid_export_energy": SENSOR_GROUP_ENERGY,
     "daily_grid_export_energy": SENSOR_GROUP_ENERGY,
@@ -262,6 +267,5 @@ SENSOR_GROUPS = {
     "meter_device_status": SENSOR_GROUP_STATUS,
     # Group 7: Financial Tracking - Earnings and revenue sensors
     "daily_earnings": SENSOR_GROUP_FINANCIAL,
-    "total_earnings": SENSOR_GROUP_FINANCIAL,
     "lifetime_earnings": SENSOR_GROUP_FINANCIAL,
 }

--- a/custom_components/sunlit/coordinators/family.py
+++ b/custom_components/sunlit/coordinators/family.py
@@ -104,6 +104,9 @@ class SunlitFamilyCoordinator(DataUpdateCoordinator):
             # Fetch SOC limits
             await self._fetch_soc_limits(family_data)
 
+            # Fetch lifetime yield & earnings totals
+            await self._fetch_lifetime_statistics(family_data)
+
             # Fetch current strategy
             await self._fetch_current_strategy(family_data)
 
@@ -190,6 +193,20 @@ class SunlitFamilyCoordinator(DataUpdateCoordinator):
                 family_data["strategy_soc_max"] = space_soc.get("strategySocMax")
         except Exception as err:
             _LOGGER.debug("Could not fetch space SOC data: %s", err)
+
+    async def _fetch_lifetime_statistics(self, family_data: dict) -> None:
+        """Fetch lifetime yield and earnings totals."""
+        try:
+            stats = await self.api_client.fetch_space_statistics_static(self.family_id)
+            if stats:
+                family_data["lifetime_yield"] = stats.get("totalYield")
+                earnings = stats.get("totalEarnings") or {}
+                family_data["lifetime_earnings"] = earnings.get("earnings")
+                # Fall back to the lifetime payload's currency if space/index
+                # did not already provide one.
+                family_data.setdefault("currency", earnings.get("currency", "EUR"))
+        except Exception as err:
+            _LOGGER.debug("Could not fetch lifetime statistics: %s", err)
 
     async def _fetch_current_strategy(self, family_data: dict) -> None:
         """Fetch current strategy."""

--- a/custom_components/sunlit/entities/helpers.py
+++ b/custom_components/sunlit/entities/helpers.py
@@ -30,11 +30,11 @@ def get_device_class_for_sensor(key: str) -> SensorDeviceClass | None:
         or "mpptenergy" in key.lower().replace("_", "").replace(" ", "")
         or key == "total_solar_energy"
         or key in ["total_grid_export_energy", "daily_grid_export_energy"]
-        or key == "daily_yield"
+        or key in ["daily_yield", "lifetime_yield"]
     ):
         return SensorDeviceClass.ENERGY
-    # Daily earnings is monetary
-    elif key == "daily_earnings":
+    # Earnings are monetary
+    elif key in ["daily_earnings", "lifetime_earnings"]:
         return SensorDeviceClass.MONETARY
     # Home power
     elif key == "home_power":
@@ -73,14 +73,16 @@ def get_state_class_for_sensor(key: str) -> SensorStateClass | None:
     # Lifetime cumulative energy sensors (never reset)
     elif (
         key == "total_yield"
+        or key == "lifetime_yield"
         or "mpptenergy" in key.lower().replace("_", "").replace(" ", "")
         or key == "total_solar_energy"
         or key == "total_grid_export_energy"
     ):
         return SensorStateClass.TOTAL_INCREASING
-    # Daily energy sensors (reset at midnight)
-    # total_power_generation is actually today's daily generation despite the misleading name
-    elif (
+    # TOTAL state class: daily counters that reset at midnight, plus
+    # lifetime_earnings (cumulative monetary value, TOTAL per HA convention).
+    # total_power_generation is actually today's daily generation.
+    elif key == "lifetime_earnings" or (
         key == "total_power_generation"
         or key == "daily_grid_export_energy"
         or key == "daily_yield"
@@ -121,7 +123,7 @@ def get_unit_for_sensor(key: str) -> str | None:
         or "mpptenergy" in key.lower().replace("_", "").replace(" ", "")
         or key == "total_solar_energy"
         or key in ["total_grid_export_energy", "daily_grid_export_energy"]
-        or key == "daily_yield"
+        or key in ["daily_yield", "lifetime_yield"]
         or key in ["total_power_generation", "total_yield"]
     ):
         return UnitOfEnergy.KILO_WATT_HOUR
@@ -257,8 +259,8 @@ def get_icon_for_sensor(key: str, device_type: str = None) -> str | None:
     # Earnings
     elif "earnings" in key:
         return "mdi:cash"
-    # Daily yield
-    elif key == "daily_yield":
+    # Yield (daily / lifetime)
+    elif key in ("daily_yield", "lifetime_yield"):
         return "mdi:solar-power-variant"
     # Home power
     elif key == "home_power":

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -359,6 +359,38 @@ async def test_fetch_device_statistics_success(api_client, mock_session):
 
 
 @pytest.mark.asyncio
+async def test_fetch_space_statistics_static_success(api_client, mock_session):
+    """Test successful fetching of lifetime yield and earnings."""
+    setup_mock_response(
+        mock_session,
+        200,
+        {
+            "code": 0,
+            "message": {"DE": "Ok"},
+            "content": {
+                "spaceId": 34038,
+                "totalYield": 1547.04,
+                "totalEarnings": {"earnings": 473.38, "currency": "EUR"},
+            },
+        },
+    )
+
+    data = await api_client.fetch_space_statistics_static(34038)
+
+    assert data["totalYield"] == 1547.04
+    assert data["totalEarnings"]["earnings"] == 473.38
+    assert data["totalEarnings"]["currency"] == "EUR"
+
+    # Verify request was made correctly (POST with spaceId payload)
+    mock_session.request.assert_called_once()
+    call_args = mock_session.request.call_args
+    assert call_args[0][0] == "POST"
+    assert "/v1.1/space/statistics/static" in call_args[0][1]
+    assert call_args[1]["json"] == {"spaceId": 34038}
+    assert call_args[1]["headers"]["Authorization"] == "Bearer test_token"
+
+
+@pytest.mark.asyncio
 async def test_fetch_device_statistics_auth_error(api_client, mock_session):
     """Test authentication error when fetching device statistics."""
     # Setup 401 response

--- a/tests/test_family_coordinator.py
+++ b/tests/test_family_coordinator.py
@@ -27,6 +27,10 @@ async def test_family_coordinator_update_success(
     api_client.get_charging_box_strategy.return_value = charging_box_strategy_response[
         "content"
     ]
+    api_client.fetch_space_statistics_static.return_value = {
+        "totalYield": 1547.04,
+        "totalEarnings": {"earnings": 473.38, "currency": "EUR"},
+    }
 
     coordinator = SunlitFamilyCoordinator(
         hass,
@@ -59,9 +63,14 @@ async def test_family_coordinator_update_success(
     assert family_data["battery_strategy"] == "SELF_CONSUMPTION"
     assert family_data["battery_full"] == False
 
+    # Check lifetime statistics
+    assert family_data["lifetime_yield"] == 1547.04
+    assert family_data["lifetime_earnings"] == 473.38
+
     # Verify API calls
     api_client.fetch_space_index.assert_called_once_with("34038")
     api_client.fetch_space_soc.assert_called_once_with("34038")
+    api_client.fetch_space_statistics_static.assert_called_once_with("34038")
     api_client.fetch_space_current_strategy.assert_called_once_with("34038")
     api_client.get_charging_box_strategy.assert_called_once_with("34038")
 
@@ -75,6 +84,7 @@ async def test_family_coordinator_partial_failure(
     api_client = AsyncMock()
     api_client.fetch_space_index.return_value = space_index_response["content"]
     api_client.fetch_space_soc.side_effect = Exception("SOC API failed")
+    api_client.fetch_space_statistics_static.side_effect = Exception("Stats API failed")
     api_client.fetch_space_current_strategy.side_effect = Exception("Strategy API failed")
     api_client.get_charging_box_strategy.side_effect = Exception("Charging box API failed")
 
@@ -97,9 +107,10 @@ async def test_family_coordinator_partial_failure(
     assert family_data["average_battery_level"] == 85
     assert family_data["total_ac_power"] == 1500  # From meter data
 
-    # Should not have SOC or strategy data
+    # Should not have SOC, strategy, or lifetime-stats data
     assert "hw_soc_min" not in family_data
     assert "battery_strategy" not in family_data
+    assert "lifetime_yield" not in family_data
 
 
 async def test_family_coordinator_complete_failure(
@@ -111,6 +122,7 @@ async def test_family_coordinator_complete_failure(
     api_client.fetch_space_index.side_effect = Exception("Complete API failure")
     api_client.fetch_device_list.side_effect = Exception("Device list API failed")
     api_client.fetch_space_soc.side_effect = Exception("SOC API failed")
+    api_client.fetch_space_statistics_static.side_effect = Exception("Stats API failed")
     api_client.fetch_space_current_strategy.side_effect = Exception("Strategy API failed")
     api_client.get_charging_box_strategy.side_effect = Exception("Charging box API failed")
 

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -331,3 +331,27 @@ class TestIconForSensor:
         assert get_icon_for_sensor("batteryMppt1InVol") == "mdi:sine-wave"
         assert get_icon_for_sensor("batteryMppt1InCur") == "mdi:current-dc"
         assert get_icon_for_sensor("batteryMppt1InPower") == "mdi:solar-power-variant"
+
+
+class TestLifetimeStatsSensors:
+    """Test classification of lifetime yield & earnings sensors (issue #155)."""
+
+    def test_lifetime_yield(self):
+        """lifetime_yield is a cumulative energy sensor in kWh."""
+        assert get_device_class_for_sensor("lifetime_yield") == SensorDeviceClass.ENERGY
+        assert (
+            get_state_class_for_sensor("lifetime_yield")
+            == SensorStateClass.TOTAL_INCREASING
+        )
+        assert get_unit_for_sensor("lifetime_yield") == UnitOfEnergy.KILO_WATT_HOUR
+        assert get_icon_for_sensor("lifetime_yield") == "mdi:solar-power-variant"
+
+    def test_lifetime_earnings(self):
+        """lifetime_earnings is a cumulative monetary sensor."""
+        assert (
+            get_device_class_for_sensor("lifetime_earnings")
+            == SensorDeviceClass.MONETARY
+        )
+        assert get_state_class_for_sensor("lifetime_earnings") == SensorStateClass.TOTAL
+        assert get_unit_for_sensor("lifetime_earnings") == "EUR"
+        assert get_icon_for_sensor("lifetime_earnings") == "mdi:cash"


### PR DESCRIPTION
## Summary

Adopts `POST /v1.1/space/statistics/static` to surface two cumulative
family-hub sensors (epic #163):

- **Lifetime Yield** — `totalYield`, energy, kWh, `state_class: total_increasing` (Energy-Dashboard eligible)
- **Lifetime Earnings** — `totalEarnings.earnings`, monetary, currency from payload, `state_class: total`

## Changes

- `const.py`: `API_SPACE_STATISTICS_STATIC`; `lifetime_yield`/`lifetime_earnings` in `FAMILY_SENSORS`; `lifetime_yield` → energy group; removed the orphan `total_earnings` group entry.
- `api_client.py`: `fetch_space_statistics_static(space_id)` (mirrors `fetch_space_soc`).
- `coordinators/family.py`: `_fetch_lifetime_statistics()` — graceful on failure, currency fallback.
- `entities/helpers.py`: device-class / state-class / unit / icon for both keys.
- `sensor.py`: no change — the generic `FAMILY_SENSORS` loop wires them to the family coordinator automatically.

## Tests

- `test_api_client`: `fetch_space_statistics_static` request/response.
- `test_family_coordinator`: success asserts the new fields; the partial/complete-failure tests now make the new fetch fail so the auto-`AsyncMock` doesn't pollute `family_data`.
- `test_sensor_helpers`: classification of both keys.

## Notes / decisions

- Key naming `lifetime_*` avoids collision with the existing device-level `total_yield` sensor.
- `lifetime_earnings` unit is statically `EUR` (same limitation as `daily_earnings`); true multi-currency would need per-entity dynamic units — out of scope.
- `lifetime_yield` overlaps conceptually with the locally-integrated `total_solar_energy`; both are valid Energy-Dashboard candidates — worth a docs note so users don't double-count.

## Test plan

- [x] Pre-commit (ruff / ruff-format / isort) passes.
- [x] Endpoint verified live against `api.sunenergyxt.com` (returns `totalYield` + `totalEarnings`).
- [ ] CI `pytest` — not runnable locally (no HA test harness).

Closes #155
🤖 Generated with [Claude Code](https://claude.com/claude-code)