### PR TITLE
feat(switch): add battery local-mode control switch (#160)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,7 @@ The integration supports the following device types:
 
 - Update interval: `DEFAULT_SCAN_INTERVAL` (30 seconds)
 - Domain: `sunlit`
-- Supported platforms: `[Platform.SENSOR, Platform.BINARY_SENSOR]`
+- Supported platforms: `[Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SWITCH]`
 - Version: `VERSION` in `const.py` (managed by release-please)
 - GitHub URL: `GITHUB_URL` in `const.py`
 

--- a/custom_components/sunlit/__init__.py
+++ b/custom_components/sunlit/__init__.py
@@ -33,7 +33,11 @@ from .event_manager import SunlitEventManager
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.SWITCH,
+]
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/custom_components/sunlit/api_client.py
+++ b/custom_components/sunlit/api_client.py
@@ -11,6 +11,7 @@ import aiohttp
 from .const import (
     API_BASE_URL,
     API_BATTERY_IO_POWER,
+    API_BATTERY_LOCAL_MODE_CONFIG,
     API_CHARGING_BOX_CHECK_STRATEGY,
     API_DEVICE_DETAILS,
     API_DEVICE_LIST,
@@ -571,6 +572,32 @@ class SunlitApiClient:
                 "Failed to fetch lifetime statistics for space %s: %s", space_id, err
             )
             raise
+
+    async def update_battery_local_mode(
+        self, device_sn: str, enable: bool
+    ) -> dict[str, Any]:
+        """Enable or disable local mode for a battery (control endpoint).
+
+        Local mode lets the battery run from on-device logic rather than cloud
+        strategy. This mutates device state.
+
+        Args:
+            device_sn: Battery serial number
+            enable: True to enable local mode, False to disable
+
+        Returns:
+            The raw API envelope (``content`` is null on success)
+
+        Raises:
+            SunlitAuthError: Authentication failed
+            SunlitConnectionError: Connection failed
+            SunlitApiError: API returned an error
+        """
+        payload = {"enable": enable, "deviceSn": device_sn}
+        _LOGGER.debug("Setting battery %s local mode to %s", device_sn, enable)
+        return await self._make_request(
+            "POST", API_BATTERY_LOCAL_MODE_CONFIG, json=payload
+        )
 
     async def fetch_space_current_strategy(
         self, family_id: str | int

--- a/custom_components/sunlit/const.py
+++ b/custom_components/sunlit/const.py
@@ -29,6 +29,7 @@ API_SPACE_STRATEGY_HISTORY = "/v1.1/space/strategyHistory"
 API_SPACE_INDEX = "/v1.5/space/index"
 API_SPACE_STATISTICS_STATIC = "/v1.1/space/statistics/static"
 API_CHARGING_BOX_CHECK_STRATEGY = "/v1.6/chargingBox/checkSpaceStrategy"
+API_BATTERY_LOCAL_MODE_CONFIG = "/v1.7/battery/updateLocalModeConfig"
 
 # Configuration keys
 CONF_EMAIL = "email"

--- a/custom_components/sunlit/coordinators/device.py
+++ b/custom_components/sunlit/coordinators/device.py
@@ -345,6 +345,21 @@ class SunlitDeviceCoordinator(DataUpdateCoordinator):
         else:
             data["module_count"] = fallback_module_count
 
+        # Local-mode capability and current state for the control switch (#160).
+        # Sourced from device details; only meaningful while the battery is online.
+        if device.get("status") == "Online":
+            try:
+                details = await self.api_client.fetch_device_details(device_id)
+                if details.get("supportLocalMode"):
+                    data["support_local_mode"] = True
+                    data["local_mode_enabled"] = details.get("localModeEnabled")
+            except Exception as err:
+                _LOGGER.debug(
+                    "Could not fetch local-mode status for device %s: %s",
+                    device_id,
+                    err,
+                )
+
     def _count_battery_modules(self, stats: dict) -> int:
         """Count physical B215 extension modules from per-slot statistics.
 

--- a/custom_components/sunlit/entities/device_switch.py
+++ b/custom_components/sunlit/entities/device_switch.py
@@ -1,0 +1,127 @@
+"""Battery local-mode control switch for the Sunlit integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from ..const import DOMAIN
+from .base import normalize_device_type
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SunlitBatteryLocalModeSwitch(CoordinatorEntity, SwitchEntity):
+    """Switch to toggle a battery's local mode.
+
+    Local mode lets the battery operate from on-device logic rather than the
+    cloud strategy. Writes go to /v1.7/battery/updateLocalModeConfig; current
+    state is read from the device coordinator (sourced from device details).
+    """
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:home-lightning-bolt"
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        entry_id: str,
+        family_id: str,
+        family_name: str,
+        device_id: str,
+        device_info_data: dict[str, Any],
+    ) -> None:
+        """Initialize the local-mode switch."""
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._family_id = family_id
+        self._family_name = family_name
+        self._device_id = device_id
+        self._device_info_data = device_info_data
+        self._device_sn = device_info_data.get("deviceSn")
+
+        device_type = device_info_data.get("deviceType", "Device")
+        normalized_type = normalize_device_type(device_type)
+        self._attr_unique_id = (
+            f"sunlit_{family_name.lower().replace(' ', '_')}_{family_id}_"
+            f"{normalized_type}_{device_id}_local_mode"
+        )
+        self._attr_name = "Local Mode"
+
+    def _device_data(self) -> dict[str, Any] | None:
+        """Return this device's entry from the coordinator data."""
+        data = self.coordinator.data or {}
+        return data.get("devices", {}).get(self._device_id)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether local mode is currently enabled."""
+        device = self._device_data()
+        if device is not None and device.get("local_mode_enabled") is not None:
+            return bool(device["local_mode_enabled"])
+        return None
+
+    @property
+    def available(self) -> bool:
+        """Return if the switch is available."""
+        device = self._device_data()
+        return (
+            self.coordinator.last_update_success
+            and device is not None
+            and device.get("local_mode_enabled") is not None
+        )
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Attach to the battery device created by the other platforms."""
+        device_sn = self._device_info_data.get("deviceSn", self._device_id)
+        return DeviceInfo(
+            identifiers={(DOMAIN, device_sn)},
+            via_device=(DOMAIN, f"family_{self._family_id}"),
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional state attributes."""
+        return {
+            "device_id": self._device_id,
+            "device_sn": self._device_sn,
+        }
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable local mode."""
+        await self._set_local_mode(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable local mode."""
+        await self._set_local_mode(False)
+
+    async def _set_local_mode(self, enable: bool) -> None:
+        """Call the control endpoint, then optimistically update and refresh."""
+        if not self._device_sn:
+            raise HomeAssistantError(
+                "Battery serial number unknown; cannot set local mode"
+            )
+        try:
+            await self.coordinator.api_client.update_battery_local_mode(
+                self._device_sn, enable
+            )
+        except Exception as err:
+            raise HomeAssistantError(
+                f"Failed to set battery local mode: {err}"
+            ) from err
+
+        # Reflect the change immediately, then refresh to confirm against the API.
+        device = self._device_data()
+        if device is not None:
+            device["local_mode_enabled"] = enable
+            self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()

--- a/custom_components/sunlit/switch.py
+++ b/custom_components/sunlit/switch.py
@@ -1,0 +1,66 @@
+"""Platform for switch integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .entities.device_switch import SunlitBatteryLocalModeSwitch
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the switch platform."""
+    integration_data = hass.data[DOMAIN][config_entry.entry_id]
+
+    # Handle both old and new data structures
+    if isinstance(integration_data, dict) and "coordinators" in integration_data:
+        coordinators = integration_data["coordinators"]
+    else:
+        coordinators = integration_data
+
+    switches = []
+
+    for family_id, coordinator_set in coordinators.items():
+        if not isinstance(coordinator_set, dict):
+            _LOGGER.warning(
+                "Old coordinator structure detected, skipping family %s", family_id
+            )
+            continue
+
+        device_coordinator = coordinator_set.get("device")
+        if not device_coordinator or not device_coordinator.data:
+            continue
+
+        devices = device_coordinator.data.get("devices", {})
+        for device_id, device_data in devices.items():
+            # Only batteries that advertise local-mode support get a switch.
+            if not device_data.get("support_local_mode"):
+                continue
+            if not (
+                device_coordinator.devices and device_id in device_coordinator.devices
+            ):
+                continue
+
+            device_info = device_coordinator.devices[device_id]
+            switches.append(
+                SunlitBatteryLocalModeSwitch(
+                    coordinator=device_coordinator,
+                    entry_id=config_entry.entry_id,
+                    family_id=device_coordinator.family_id,
+                    family_name=device_coordinator.family_name,
+                    device_id=device_id,
+                    device_info_data=device_info,
+                )
+            )
+
+    async_add_entities(switches, True)

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -391,6 +391,40 @@ async def test_fetch_space_statistics_static_success(api_client, mock_session):
 
 
 @pytest.mark.asyncio
+async def test_update_battery_local_mode_success(api_client, mock_session):
+    """Test enabling/disabling battery local mode (control endpoint)."""
+    setup_mock_response(
+        mock_session,
+        200,
+        {"code": 0, "message": {"DE": "Ok"}, "content": None},
+    )
+
+    result = await api_client.update_battery_local_mode("dcbdccbffe3d", False)
+
+    assert result["code"] == 0
+
+    mock_session.request.assert_called_once()
+    call_args = mock_session.request.call_args
+    assert call_args[0][0] == "POST"
+    assert "/v1.7/battery/updateLocalModeConfig" in call_args[0][1]
+    assert call_args[1]["json"] == {"enable": False, "deviceSn": "dcbdccbffe3d"}
+    assert call_args[1]["headers"]["Authorization"] == "Bearer test_token"
+
+
+@pytest.mark.asyncio
+async def test_update_battery_local_mode_api_error(api_client, mock_session):
+    """Test that an API-level error toggling local mode raises."""
+    setup_mock_response(
+        mock_session,
+        200,
+        {"code": 1, "message": {"DE": "Fehler"}, "content": None},
+    )
+
+    with pytest.raises(SunlitApiError):
+        await api_client.update_battery_local_mode("dcbdccbffe3d", True)
+
+
+@pytest.mark.asyncio
 async def test_fetch_device_statistics_auth_error(api_client, mock_session):
     """Test authentication error when fetching device statistics."""
     # Setup 401 response

--- a/tests/test_device_coordinator.py
+++ b/tests/test_device_coordinator.py
@@ -44,6 +44,11 @@ async def test_device_coordinator_update_success(
     api_client.fetch_device_statistics.return_value = device_statistics_response[
         "content"
     ]
+    api_client.fetch_device_details.return_value = {
+        "deviceSn": "dcbdccbffe3d",
+        "supportLocalMode": True,
+        "localModeEnabled": True,
+    }
 
     coordinator = SunlitDeviceCoordinator(
         hass,
@@ -81,6 +86,10 @@ async def test_device_coordinator_update_success(
     assert battery["batterySoc"] == 85
     assert battery["battery1Soc"] == 84
     assert battery["battery2Soc"] == 86
+
+    # Local-mode control state (issue #160)
+    assert battery["support_local_mode"] is True
+    assert battery["local_mode_enabled"] is True
 
     # Check aggregates
     aggregates = data["aggregates"]

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,118 @@
+"""Tests for the battery local-mode switch (issue #160)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.sunlit.entities.device_switch import (
+    SunlitBatteryLocalModeSwitch,
+)
+
+
+def _make_switch(local_mode_enabled=True, device_sn="dcbdccbffe3d"):
+    """Build a switch wired to a mock device coordinator."""
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.api_client = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.data = {
+        "devices": {
+            "battery_001": {
+                "support_local_mode": True,
+                "local_mode_enabled": local_mode_enabled,
+            }
+        }
+    }
+
+    switch = SunlitBatteryLocalModeSwitch(
+        coordinator=coordinator,
+        entry_id="entry",
+        family_id="34038",
+        family_name="Test Family",
+        device_id="battery_001",
+        device_info_data={
+            "deviceSn": device_sn,
+            "deviceType": "ENERGY_STORAGE_BATTERY",
+        },
+    )
+    # Bypass HA state writes (no hass in these unit tests).
+    switch.async_write_ha_state = MagicMock()
+    return switch, coordinator
+
+
+def test_is_on_reflects_coordinator():
+    """is_on tracks the coordinator's local_mode_enabled value."""
+    on_switch, _ = _make_switch(True)
+    assert on_switch.is_on is True
+
+    off_switch, _ = _make_switch(False)
+    assert off_switch.is_on is False
+
+
+def test_is_on_none_when_missing():
+    """is_on is None when the value is absent."""
+    switch, coordinator = _make_switch(True)
+    coordinator.data["devices"]["battery_001"].pop("local_mode_enabled")
+    assert switch.is_on is None
+    assert switch.available is False
+
+
+def test_unique_id_and_name():
+    """Switch has a stable unique_id and a short name."""
+    switch, _ = _make_switch()
+    assert (
+        switch.unique_id
+        == "sunlit_test_family_34038_battery_battery_001_local_mode"
+    )
+    assert switch._attr_name == "Local Mode"
+
+
+@pytest.mark.asyncio
+async def test_turn_on_calls_api_and_refreshes():
+    """Turning on writes via the API, updates state, and refreshes."""
+    switch, coordinator = _make_switch(False)
+
+    await switch.async_turn_on()
+
+    coordinator.api_client.update_battery_local_mode.assert_awaited_once_with(
+        "dcbdccbffe3d", True
+    )
+    # Optimistic update applied
+    assert coordinator.data["devices"]["battery_001"]["local_mode_enabled"] is True
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_turn_off_calls_api():
+    """Turning off sends enable=False with the device serial."""
+    switch, coordinator = _make_switch(True)
+
+    await switch.async_turn_off()
+
+    coordinator.api_client.update_battery_local_mode.assert_awaited_once_with(
+        "dcbdccbffe3d", False
+    )
+
+
+@pytest.mark.asyncio
+async def test_api_error_raises_home_assistant_error():
+    """A failing control call surfaces as HomeAssistantError."""
+    switch, coordinator = _make_switch(True)
+    coordinator.api_client.update_battery_local_mode.side_effect = Exception("boom")
+
+    with pytest.raises(HomeAssistantError):
+        await switch.async_turn_on()
+
+    coordinator.async_request_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_serial_raises():
+    """Without a device serial the switch refuses to write."""
+    switch, coordinator = _make_switch(True, device_sn=None)
+
+    with pytest.raises(HomeAssistantError):
+        await switch.async_turn_on()
+
+    coordinator.api_client.update_battery_local_mode.assert_not_awaited()


### PR DESCRIPTION
## Summary

Adds the integration's first **control platform** (`switch`) with a per-battery
**Local Mode** switch backed by `POST /v1.7/battery/updateLocalModeConfig`
(epic #163). Local mode lets the battery run from on-device logic rather than
the cloud strategy.

## Changes

- `const.py`: `API_BATTERY_LOCAL_MODE_CONFIG` endpoint.
- `api_client.py`: `update_battery_local_mode(device_sn, enable)` write method (raises `SunlitApiError` on `code != 0`).
- `coordinators/device.py`: sources `supportLocalMode` / `localModeEnabled` from `fetch_device_details` for **online** batteries (reuses the previously-unused method).
- `entities/device_switch.py`: `SunlitBatteryLocalModeSwitch` — `is_on` from coordinator data, optimistic update + `async_request_refresh()`, errors surfaced as `HomeAssistantError`, attaches to the battery device via `via_device`.
- `switch.py`: new platform; only creates the switch when the battery advertises `support_local_mode`.
- `__init__.py`: registers `Platform.SWITCH`; `CLAUDE.md` supported-platforms doc updated.

## Behaviour / safety

- The control endpoint is only invoked when a user toggles the switch — never during polling.
- Optimistic state flip for instant UI feedback, then a coordinator refresh confirms against the API.
- Switch is absent for batteries that don't report `supportLocalMode`, and unavailable while offline.

## Tests

- `test_api_client`: write success + API-error path.
- `test_device_coordinator`: battery now exposes `support_local_mode`/`local_mode_enabled` (pinned the new `fetch_device_details` mock so it doesn't pollute the success assertions).
- `test_switch.py`: is_on / availability / turn_on / turn_off / API-error → `HomeAssistantError` / missing-serial guard.

## Test plan

- [x] Pre-commit (ruff / ruff-format / isort) passes.
- [x] Endpoint shape verified against the capture (`{enable, deviceSn}` → `content: null`).
- [ ] CI `pytest` + `hassfest` (new platform) — not runnable locally (no HA test harness).

Closes #160
🤖 Generated with [Claude Code](https://claude.com/claude-code)