### PR TITLE
feat(binary_sensor): add local-mode / UPS status sensors (#157)

### DIFF
--- a/custom_components/sunlit/api_client.py
+++ b/custom_components/sunlit/api_client.py
@@ -22,6 +22,7 @@ from .const import (
     API_SPACE_SOC,
     API_SPACE_STATISTICS_STATIC,
     API_SPACE_STRATEGY_HISTORY,
+    API_STRATEGY_DEVICE_STATUS,
     API_USER_LOGIN,
 )
 
@@ -598,6 +599,47 @@ class SunlitApiClient:
         return await self._make_request(
             "POST", API_BATTERY_LOCAL_MODE_CONFIG, json=payload
         )
+
+    async def fetch_strategy_device_status(self, space_id: str | int) -> dict[str, Any]:
+        """Fetch local-mode / UPS status for the strategy-capable device.
+
+        Args:
+            space_id: The space/family ID
+
+        Returns:
+            Dictionary containing:
+            - batteryLocalModeEnabled: Whether battery local mode is enabled
+            - aioLocalModeEnabled: Whether AIO local mode is enabled
+            - aioUpsEnabled: Whether AIO UPS mode is enabled
+            - deviceModel: Device model identifier
+
+        Raises:
+            SunlitAuthError: Authentication failed
+            SunlitConnectionError: Connection failed
+            SunlitApiError: API returned an error
+        """
+        try:
+            payload = {"spaceId": int(space_id)}
+            response = await self._make_request(
+                "POST", API_STRATEGY_DEVICE_STATUS, json=payload
+            )
+
+            _LOGGER.debug(
+                "Strategy device status response for %s: %s", space_id, response
+            )
+
+            if "content" in response:
+                return response["content"]
+
+            return {}
+
+        except SunlitApiError as err:
+            _LOGGER.error(
+                "Failed to fetch strategy device status for space %s: %s",
+                space_id,
+                err,
+            )
+            raise
 
     async def fetch_space_current_strategy(
         self, family_id: str | int

--- a/custom_components/sunlit/binary_sensor.py
+++ b/custom_components/sunlit/binary_sensor.py
@@ -93,6 +93,22 @@ FAMILY_BINARY_SENSORS = {
         "device_class": None,
         "icon": "mdi:lightning-bolt",
     },
+    # Local-mode / UPS status from strategy/device/status endpoint
+    "battery_local_mode_enabled": {
+        "name": "Battery Local Mode",
+        "device_class": None,
+        "icon": "mdi:home-lightning-bolt",
+    },
+    "aio_local_mode_enabled": {
+        "name": "AIO Local Mode",
+        "device_class": None,
+        "icon": "mdi:home-lightning-bolt",
+    },
+    "aio_ups_enabled": {
+        "name": "AIO UPS",
+        "device_class": None,
+        "icon": "mdi:power-plug-battery",
+    },
 }
 
 DEVICE_BINARY_SENSORS = {

--- a/custom_components/sunlit/const.py
+++ b/custom_components/sunlit/const.py
@@ -30,6 +30,7 @@ API_SPACE_INDEX = "/v1.5/space/index"
 API_SPACE_STATISTICS_STATIC = "/v1.1/space/statistics/static"
 API_CHARGING_BOX_CHECK_STRATEGY = "/v1.6/chargingBox/checkSpaceStrategy"
 API_BATTERY_LOCAL_MODE_CONFIG = "/v1.7/battery/updateLocalModeConfig"
+API_STRATEGY_DEVICE_STATUS = "/v1.7/strategy/device/status"
 
 # Configuration keys
 CONF_EMAIL = "email"

--- a/custom_components/sunlit/coordinators/family.py
+++ b/custom_components/sunlit/coordinators/family.py
@@ -107,6 +107,9 @@ class SunlitFamilyCoordinator(DataUpdateCoordinator):
             # Fetch lifetime yield & earnings totals
             await self._fetch_lifetime_statistics(family_data)
 
+            # Fetch local-mode / UPS device status
+            await self._fetch_strategy_device_status(family_data)
+
             # Fetch current strategy
             await self._fetch_current_strategy(family_data)
 
@@ -207,6 +210,21 @@ class SunlitFamilyCoordinator(DataUpdateCoordinator):
                 family_data.setdefault("currency", earnings.get("currency", "EUR"))
         except Exception as err:
             _LOGGER.debug("Could not fetch lifetime statistics: %s", err)
+
+    async def _fetch_strategy_device_status(self, family_data: dict) -> None:
+        """Fetch local-mode / UPS status flags for the strategy device."""
+        try:
+            status = await self.api_client.fetch_strategy_device_status(self.family_id)
+            if status:
+                family_data["battery_local_mode_enabled"] = status.get(
+                    "batteryLocalModeEnabled"
+                )
+                family_data["aio_local_mode_enabled"] = status.get(
+                    "aioLocalModeEnabled"
+                )
+                family_data["aio_ups_enabled"] = status.get("aioUpsEnabled")
+        except Exception as err:
+            _LOGGER.debug("Could not fetch strategy device status: %s", err)
 
     async def _fetch_current_strategy(self, family_data: dict) -> None:
         """Fetch current strategy."""

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -425,6 +425,38 @@ async def test_update_battery_local_mode_api_error(api_client, mock_session):
 
 
 @pytest.mark.asyncio
+async def test_fetch_strategy_device_status_success(api_client, mock_session):
+    """Test fetching local-mode / UPS device status."""
+    setup_mock_response(
+        mock_session,
+        200,
+        {
+            "code": 0,
+            "message": {"DE": "Ok"},
+            "content": {
+                "batteryLocalModeEnabled": True,
+                "aioLocalModeEnabled": False,
+                "aioUpsEnabled": False,
+                "deviceModel": "BK_215",
+            },
+        },
+    )
+
+    data = await api_client.fetch_strategy_device_status(34038)
+
+    assert data["batteryLocalModeEnabled"] is True
+    assert data["aioLocalModeEnabled"] is False
+    assert data["aioUpsEnabled"] is False
+
+    mock_session.request.assert_called_once()
+    call_args = mock_session.request.call_args
+    assert call_args[0][0] == "POST"
+    assert "/v1.7/strategy/device/status" in call_args[0][1]
+    assert call_args[1]["json"] == {"spaceId": 34038}
+    assert call_args[1]["headers"]["Authorization"] == "Bearer test_token"
+
+
+@pytest.mark.asyncio
 async def test_fetch_device_statistics_auth_error(api_client, mock_session):
     """Test authentication error when fetching device statistics."""
     # Setup 401 response

--- a/tests/test_family_coordinator.py
+++ b/tests/test_family_coordinator.py
@@ -31,6 +31,12 @@ async def test_family_coordinator_update_success(
         "totalYield": 1547.04,
         "totalEarnings": {"earnings": 473.38, "currency": "EUR"},
     }
+    api_client.fetch_strategy_device_status.return_value = {
+        "batteryLocalModeEnabled": True,
+        "aioLocalModeEnabled": False,
+        "aioUpsEnabled": False,
+        "deviceModel": "BK_215",
+    }
 
     coordinator = SunlitFamilyCoordinator(
         hass,
@@ -67,10 +73,16 @@ async def test_family_coordinator_update_success(
     assert family_data["lifetime_yield"] == 1547.04
     assert family_data["lifetime_earnings"] == 473.38
 
+    # Check local-mode / UPS device status
+    assert family_data["battery_local_mode_enabled"] is True
+    assert family_data["aio_local_mode_enabled"] is False
+    assert family_data["aio_ups_enabled"] is False
+
     # Verify API calls
     api_client.fetch_space_index.assert_called_once_with("34038")
     api_client.fetch_space_soc.assert_called_once_with("34038")
     api_client.fetch_space_statistics_static.assert_called_once_with("34038")
+    api_client.fetch_strategy_device_status.assert_called_once_with("34038")
     api_client.fetch_space_current_strategy.assert_called_once_with("34038")
     api_client.get_charging_box_strategy.assert_called_once_with("34038")
 
@@ -85,6 +97,7 @@ async def test_family_coordinator_partial_failure(
     api_client.fetch_space_index.return_value = space_index_response["content"]
     api_client.fetch_space_soc.side_effect = Exception("SOC API failed")
     api_client.fetch_space_statistics_static.side_effect = Exception("Stats API failed")
+    api_client.fetch_strategy_device_status.side_effect = Exception("Status API failed")
     api_client.fetch_space_current_strategy.side_effect = Exception("Strategy API failed")
     api_client.get_charging_box_strategy.side_effect = Exception("Charging box API failed")
 
@@ -107,10 +120,11 @@ async def test_family_coordinator_partial_failure(
     assert family_data["average_battery_level"] == 85
     assert family_data["total_ac_power"] == 1500  # From meter data
 
-    # Should not have SOC, strategy, or lifetime-stats data
+    # Should not have SOC, strategy, lifetime-stats, or device-status data
     assert "hw_soc_min" not in family_data
     assert "battery_strategy" not in family_data
     assert "lifetime_yield" not in family_data
+    assert "battery_local_mode_enabled" not in family_data
 
 
 async def test_family_coordinator_complete_failure(
@@ -123,6 +137,7 @@ async def test_family_coordinator_complete_failure(
     api_client.fetch_device_list.side_effect = Exception("Device list API failed")
     api_client.fetch_space_soc.side_effect = Exception("SOC API failed")
     api_client.fetch_space_statistics_static.side_effect = Exception("Stats API failed")
+    api_client.fetch_strategy_device_status.side_effect = Exception("Status API failed")
     api_client.fetch_space_current_strategy.side_effect = Exception("Strategy API failed")
     api_client.get_charging_box_strategy.side_effect = Exception("Charging box API failed")
 


### PR DESCRIPTION
## Summary

Surfaces the flags from `POST /v1.7/strategy/device/status` as family-level
**diagnostic binary sensors** (epic #163):

- **Battery Local Mode** (`battery_local_mode_enabled`)
- **AIO Local Mode** (`aio_local_mode_enabled`)
- **AIO UPS** (`aio_ups_enabled`)

These are the canonical read-only status for the flags. The **#160 switch**
remains the *control* for battery local mode — no behaviour change there.
(AIO = the all-in-one product line; both `false` on a BK215-only setup.)

## Changes

- `const.py`: `API_STRATEGY_DEVICE_STATUS` endpoint.
- `api_client.py`: `fetch_strategy_device_status(space_id)`.
- `coordinators/family.py`: fetches the flags (graceful on failure).
- `binary_sensor.py`: three new entries in `FAMILY_BINARY_SENSORS` (auto-wired by the existing loop).

## Tests

- `test_api_client`: request/response of the new fetch.
- `test_family_coordinator`: flags present on success; absent on failure. The failure-path tests pin the new call so `complete_failure` still yields `{"family": {}}` (same pattern used for #155/#160's auto-mock gotcha).

## Test plan

- [x] Pre-commit (ruff / ruff-format / isort) passes.
- [x] Endpoint shape verified live against `api.sunenergyxt.com`.
- [ ] CI `pytest` — not runnable locally (no HA test harness).

Closes #157
🤖 Generated with [Claude Code](https://claude.com/claude-code)