### PR TITLE
feat(sensors): add dynamic electricity tariff price sensors (#154)

### DIFF
--- a/custom_components/sunlit/api_client.py
+++ b/custom_components/sunlit/api_client.py
@@ -23,6 +23,7 @@ from .const import (
     API_SPACE_STATISTICS_STATIC,
     API_SPACE_STRATEGY_HISTORY,
     API_STRATEGY_DEVICE_STATUS,
+    API_TARIFF_INDEX,
     API_USER_LOGIN,
 )
 
@@ -599,6 +600,42 @@ class SunlitApiClient:
         return await self._make_request(
             "POST", API_BATTERY_LOCAL_MODE_CONFIG, json=payload
         )
+
+    async def fetch_tariff_index(self, space_id: str | int) -> dict[str, Any]:
+        """Fetch dynamic electricity tariff/pricing for a space.
+
+        Args:
+            space_id: The space/family ID
+
+        Returns:
+            Dictionary containing:
+            - rabotHasContract: Whether a Rabot dynamic-tariff contract exists
+            - rabotHourPriceDTO: Current hourly price block (may be null) with
+              priceInCentPerKwh, avgPriceInCentPerKwh, highestPriceInCentPerKwh,
+              lowestPriceInCentPerKwh, priceTag, hour, timestamp
+            - countryCode
+
+        Raises:
+            SunlitAuthError: Authentication failed
+            SunlitConnectionError: Connection failed
+            SunlitApiError: API returned an error
+        """
+        try:
+            payload = {"spaceId": int(space_id)}
+            response = await self._make_request("POST", API_TARIFF_INDEX, json=payload)
+
+            _LOGGER.debug("Tariff index response for %s: %s", space_id, response)
+
+            if "content" in response:
+                return response["content"]
+
+            return {}
+
+        except SunlitApiError as err:
+            _LOGGER.error(
+                "Failed to fetch tariff index for space %s: %s", space_id, err
+            )
+            raise
 
     async def fetch_strategy_device_status(self, space_id: str | int) -> dict[str, Any]:
         """Fetch local-mode / UPS status for the strategy-capable device.

--- a/custom_components/sunlit/binary_sensor.py
+++ b/custom_components/sunlit/binary_sensor.py
@@ -109,6 +109,12 @@ FAMILY_BINARY_SENSORS = {
         "device_class": None,
         "icon": "mdi:power-plug-battery",
     },
+    # Dynamic tariff status from tariff/index endpoint
+    "rabot_has_contract": {
+        "name": "Rabot Contract",
+        "device_class": None,
+        "icon": "mdi:file-document-check",
+    },
 }
 
 DEVICE_BINARY_SENSORS = {

--- a/custom_components/sunlit/const.py
+++ b/custom_components/sunlit/const.py
@@ -31,6 +31,7 @@ API_SPACE_STATISTICS_STATIC = "/v1.1/space/statistics/static"
 API_CHARGING_BOX_CHECK_STRATEGY = "/v1.6/chargingBox/checkSpaceStrategy"
 API_BATTERY_LOCAL_MODE_CONFIG = "/v1.7/battery/updateLocalModeConfig"
 API_STRATEGY_DEVICE_STATUS = "/v1.7/strategy/device/status"
+API_TARIFF_INDEX = "/v1.6/tariff/index"
 
 # Configuration keys
 CONF_EMAIL = "email"
@@ -173,6 +174,12 @@ FAMILY_SENSORS = {
     # Lifetime totals from space/statistics/static endpoint
     "lifetime_yield": "Lifetime Yield",
     "lifetime_earnings": "Lifetime Earnings",
+    # Dynamic electricity tariff from tariff/index endpoint (Rabot)
+    "electricity_price": "Electricity Price",
+    "electricity_price_avg": "Electricity Price Average",
+    "electricity_price_high": "Electricity Price High",
+    "electricity_price_low": "Electricity Price Low",
+    "electricity_price_tag": "Electricity Price Tag",
     # Total solar production tracking
     "total_solar_energy": "Total Solar Energy",
     "total_solar_power": "Total Solar Power",
@@ -270,4 +277,9 @@ SENSOR_GROUPS = {
     # Group 7: Financial Tracking - Earnings and revenue sensors
     "daily_earnings": SENSOR_GROUP_FINANCIAL,
     "lifetime_earnings": SENSOR_GROUP_FINANCIAL,
+    "electricity_price": SENSOR_GROUP_FINANCIAL,
+    "electricity_price_avg": SENSOR_GROUP_FINANCIAL,
+    "electricity_price_high": SENSOR_GROUP_FINANCIAL,
+    "electricity_price_low": SENSOR_GROUP_FINANCIAL,
+    "electricity_price_tag": SENSOR_GROUP_FINANCIAL,
 }

--- a/custom_components/sunlit/coordinators/family.py
+++ b/custom_components/sunlit/coordinators/family.py
@@ -110,6 +110,9 @@ class SunlitFamilyCoordinator(DataUpdateCoordinator):
             # Fetch local-mode / UPS device status
             await self._fetch_strategy_device_status(family_data)
 
+            # Fetch dynamic electricity tariff / pricing
+            await self._fetch_tariff(family_data)
+
             # Fetch current strategy
             await self._fetch_current_strategy(family_data)
 
@@ -225,6 +228,32 @@ class SunlitFamilyCoordinator(DataUpdateCoordinator):
                 family_data["aio_ups_enabled"] = status.get("aioUpsEnabled")
         except Exception as err:
             _LOGGER.debug("Could not fetch strategy device status: %s", err)
+
+    async def _fetch_tariff(self, family_data: dict) -> None:
+        """Fetch dynamic electricity tariff and current price block."""
+        try:
+            tariff = await self.api_client.fetch_tariff_index(self.family_id)
+            if tariff:
+                family_data["rabot_has_contract"] = tariff.get(
+                    "rabotHasContract", False
+                )
+                # rabotHourPriceDTO is null when no dynamic tariff is configured;
+                # only emit price sensors when a price block is present.
+                price = tariff.get("rabotHourPriceDTO")
+                if price:
+                    family_data["electricity_price"] = price.get("priceInCentPerKwh")
+                    family_data["electricity_price_avg"] = price.get(
+                        "avgPriceInCentPerKwh"
+                    )
+                    family_data["electricity_price_high"] = price.get(
+                        "highestPriceInCentPerKwh"
+                    )
+                    family_data["electricity_price_low"] = price.get(
+                        "lowestPriceInCentPerKwh"
+                    )
+                    family_data["electricity_price_tag"] = price.get("priceTag")
+        except Exception as err:
+            _LOGGER.debug("Could not fetch tariff index: %s", err)
 
     async def _fetch_current_strategy(self, family_data: dict) -> None:
         """Fetch current strategy."""

--- a/custom_components/sunlit/entities/helpers.py
+++ b/custom_components/sunlit/entities/helpers.py
@@ -110,6 +110,10 @@ def get_state_class_for_sensor(key: str) -> SensorStateClass | None:
         "battery_discharging_remaining",
         "inverter_current_power",
         "total_solar_power",
+        "electricity_price",
+        "electricity_price_avg",
+        "electricity_price_high",
+        "electricity_price_low",
     ]:
         return SensorStateClass.MEASUREMENT
     return None
@@ -158,6 +162,13 @@ def get_unit_for_sensor(key: str) -> str | None:
         "soc" in key.lower() or "battery_level" in key or "average_battery_level" in key
     ):
         return PERCENTAGE
+    elif key in (
+        "electricity_price",
+        "electricity_price_avg",
+        "electricity_price_high",
+        "electricity_price_low",
+    ):
+        return "ct/kWh"
     elif "earnings" in key:
         return "EUR"  # Could be made configurable, will use currency field
     return None
@@ -259,6 +270,11 @@ def get_icon_for_sensor(key: str, device_type: str = None) -> str | None:
     # Earnings
     elif "earnings" in key:
         return "mdi:cash"
+    # Electricity price (dynamic tariff)
+    elif key == "electricity_price_tag":
+        return "mdi:tag-outline"
+    elif key.startswith("electricity_price"):
+        return "mdi:cash-multiple"
     # Yield (daily / lifetime)
     elif key in ("daily_yield", "lifetime_yield"):
         return "mdi:solar-power-variant"

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -457,6 +457,44 @@ async def test_fetch_strategy_device_status_success(api_client, mock_session):
 
 
 @pytest.mark.asyncio
+async def test_fetch_tariff_index_success(api_client, mock_session):
+    """Test fetching dynamic electricity tariff/pricing."""
+    setup_mock_response(
+        mock_session,
+        200,
+        {
+            "code": 0,
+            "message": {"DE": "Ok"},
+            "content": {
+                "rabotHasContract": True,
+                "rabotHourPriceDTO": {
+                    "priceInCentPerKwh": -0.2,
+                    "avgPriceInCentPerKwh": 6.67,
+                    "highestPriceInCentPerKwh": 15.32,
+                    "lowestPriceInCentPerKwh": -7.59,
+                    "priceTag": "CHEAP",
+                    "hour": 16,
+                },
+                "countryCode": "DE",
+            },
+        },
+    )
+
+    data = await api_client.fetch_tariff_index(34038)
+
+    assert data["rabotHasContract"] is True
+    assert data["rabotHourPriceDTO"]["priceInCentPerKwh"] == -0.2
+    assert data["rabotHourPriceDTO"]["priceTag"] == "CHEAP"
+
+    mock_session.request.assert_called_once()
+    call_args = mock_session.request.call_args
+    assert call_args[0][0] == "POST"
+    assert "/v1.6/tariff/index" in call_args[0][1]
+    assert call_args[1]["json"] == {"spaceId": 34038}
+    assert call_args[1]["headers"]["Authorization"] == "Bearer test_token"
+
+
+@pytest.mark.asyncio
 async def test_fetch_device_statistics_auth_error(api_client, mock_session):
     """Test authentication error when fetching device statistics."""
     # Setup 401 response

--- a/tests/test_family_coordinator.py
+++ b/tests/test_family_coordinator.py
@@ -37,6 +37,17 @@ async def test_family_coordinator_update_success(
         "aioUpsEnabled": False,
         "deviceModel": "BK_215",
     }
+    api_client.fetch_tariff_index.return_value = {
+        "rabotHasContract": True,
+        "rabotHourPriceDTO": {
+            "priceInCentPerKwh": -0.2,
+            "avgPriceInCentPerKwh": 6.67,
+            "highestPriceInCentPerKwh": 15.32,
+            "lowestPriceInCentPerKwh": -7.59,
+            "priceTag": "CHEAP",
+            "hour": 16,
+        },
+    }
 
     coordinator = SunlitFamilyCoordinator(
         hass,
@@ -78,10 +89,19 @@ async def test_family_coordinator_update_success(
     assert family_data["aio_local_mode_enabled"] is False
     assert family_data["aio_ups_enabled"] is False
 
+    # Check dynamic tariff / pricing
+    assert family_data["rabot_has_contract"] is True
+    assert family_data["electricity_price"] == -0.2
+    assert family_data["electricity_price_avg"] == 6.67
+    assert family_data["electricity_price_high"] == 15.32
+    assert family_data["electricity_price_low"] == -7.59
+    assert family_data["electricity_price_tag"] == "CHEAP"
+
     # Verify API calls
     api_client.fetch_space_index.assert_called_once_with("34038")
     api_client.fetch_space_soc.assert_called_once_with("34038")
     api_client.fetch_space_statistics_static.assert_called_once_with("34038")
+    api_client.fetch_tariff_index.assert_called_once_with("34038")
     api_client.fetch_strategy_device_status.assert_called_once_with("34038")
     api_client.fetch_space_current_strategy.assert_called_once_with("34038")
     api_client.get_charging_box_strategy.assert_called_once_with("34038")
@@ -98,6 +118,7 @@ async def test_family_coordinator_partial_failure(
     api_client.fetch_space_soc.side_effect = Exception("SOC API failed")
     api_client.fetch_space_statistics_static.side_effect = Exception("Stats API failed")
     api_client.fetch_strategy_device_status.side_effect = Exception("Status API failed")
+    api_client.fetch_tariff_index.side_effect = Exception("Tariff API failed")
     api_client.fetch_space_current_strategy.side_effect = Exception("Strategy API failed")
     api_client.get_charging_box_strategy.side_effect = Exception("Charging box API failed")
 
@@ -120,11 +141,12 @@ async def test_family_coordinator_partial_failure(
     assert family_data["average_battery_level"] == 85
     assert family_data["total_ac_power"] == 1500  # From meter data
 
-    # Should not have SOC, strategy, lifetime-stats, or device-status data
+    # Should not have SOC, strategy, lifetime-stats, device-status, or tariff data
     assert "hw_soc_min" not in family_data
     assert "battery_strategy" not in family_data
     assert "lifetime_yield" not in family_data
     assert "battery_local_mode_enabled" not in family_data
+    assert "electricity_price" not in family_data
 
 
 async def test_family_coordinator_complete_failure(
@@ -138,6 +160,7 @@ async def test_family_coordinator_complete_failure(
     api_client.fetch_space_soc.side_effect = Exception("SOC API failed")
     api_client.fetch_space_statistics_static.side_effect = Exception("Stats API failed")
     api_client.fetch_strategy_device_status.side_effect = Exception("Status API failed")
+    api_client.fetch_tariff_index.side_effect = Exception("Tariff API failed")
     api_client.fetch_space_current_strategy.side_effect = Exception("Strategy API failed")
     api_client.get_charging_box_strategy.side_effect = Exception("Charging box API failed")
 

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -355,3 +355,30 @@ class TestLifetimeStatsSensors:
         assert get_state_class_for_sensor("lifetime_earnings") == SensorStateClass.TOTAL
         assert get_unit_for_sensor("lifetime_earnings") == "EUR"
         assert get_icon_for_sensor("lifetime_earnings") == "mdi:cash"
+
+
+class TestElectricityPriceSensors:
+    """Test classification of dynamic tariff price sensors (issue #154)."""
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "electricity_price",
+            "electricity_price_avg",
+            "electricity_price_high",
+            "electricity_price_low",
+        ],
+    )
+    def test_numeric_price(self, key):
+        """Numeric price sensors are ct/kWh measurements with no device class."""
+        assert get_device_class_for_sensor(key) is None
+        assert get_state_class_for_sensor(key) == SensorStateClass.MEASUREMENT
+        assert get_unit_for_sensor(key) == "ct/kWh"
+        assert get_icon_for_sensor(key) == "mdi:cash-multiple"
+
+    def test_price_tag(self):
+        """The price tag is a plain text sensor."""
+        assert get_device_class_for_sensor("electricity_price_tag") is None
+        assert get_state_class_for_sensor("electricity_price_tag") is None
+        assert get_unit_for_sensor("electricity_price_tag") is None
+        assert get_icon_for_sensor("electricity_price_tag") == "mdi:tag-outline"


### PR DESCRIPTION
## Summary

Surfaces the Rabot dynamic-tariff prices from `POST /v1.6/tariff/index` as
**five family-hub sensors** + a contract binary sensor (epic #163):

| Entity | Source | Unit |
|---|---|---|
| Electricity Price | `rabotHourPriceDTO.priceInCentPerKwh` | ct/kWh |
| Electricity Price Average | `avgPriceInCentPerKwh` | ct/kWh |
| Electricity Price High | `highestPriceInCentPerKwh` | ct/kWh |
| Electricity Price Low | `lowestPriceInCentPerKwh` | ct/kWh |
| Electricity Price Tag | `priceTag` (VERY_CHEAP…VERY_EXPENSIVE) | — |
| Rabot Contract (binary) | `rabotHasContract` | — |

Negative prices are valid for dynamic tariffs. Price sensors are only emitted
when `rabotHourPriceDTO` is present (graceful when no dynamic tariff). Numeric
price sensors use `state_class: measurement` and no device_class (a per-kWh
rate isn't a valid `monetary` unit).

## Changes
- `const.py`: `API_TARIFF_INDEX`; 5 `FAMILY_SENSORS` + financial grouping.
- `api_client.py`: `fetch_tariff_index(space_id)`.
- `coordinators/family.py`: tariff fetch (graceful on failure / null price).
- `binary_sensor.py`: `rabot_has_contract`.
- `entities/helpers.py`: ct/kWh unit + measurement state_class + icons.

## Tests
- `test_api_client`: tariff fetch.
- `test_family_coordinator`: price fields present on success / absent on failure (failure-path tests pinned).
- `test_sensor_helpers`: price-sensor classification.

## ⚠️ Stacked on #170 (#157)
This branches off `feat/issue-157-device-status` (shared family-coordinator
plumbing). **Merge #170 first**; GitHub will then retarget this PR to `main`.

## Test plan
- [x] Pre-commit passes; endpoint verified live (`api.sunenergyxt.com`).
- [ ] CI `pytest` — not runnable locally (no HA harness).

Closes #154
🤖 Generated with [Claude Code](https://claude.com/claude-code)