### PR TITLE
feat(sensors): add energy self-use & self-sufficiency rates (#168)

### DIFF
--- a/custom_components/sunlit/api_client.py
+++ b/custom_components/sunlit/api_client.py
@@ -20,6 +20,7 @@ from .const import (
     API_SPACE_CURRENT_STRATEGY,
     API_SPACE_INDEX,
     API_SPACE_SOC,
+    API_SPACE_STATISTICS_DYNAMIC_ENERGY,
     API_SPACE_STATISTICS_STATIC,
     API_SPACE_STRATEGY_HISTORY,
     API_STRATEGY_DEVICE_STATUS,
@@ -572,6 +573,60 @@ class SunlitApiClient:
         except SunlitApiError as err:
             _LOGGER.error(
                 "Failed to fetch lifetime statistics for space %s: %s", space_id, err
+            )
+            raise
+
+    async def fetch_space_statistics_dynamic_energy(
+        self,
+        space_id: str | int,
+        year: int | None = None,
+        month: int | None = None,
+    ) -> dict[str, Any]:
+        """Fetch energy distribution & self-consumption for a space.
+
+        Granularity follows the optional year/month (see openapi.yaml). With
+        no year/month the response is all-time per-year buckets.
+
+        Args:
+            space_id: The space/family ID
+            year: Optional year (selects per-month or, with month, per-day)
+            month: Optional month 1-12 (requires year; yields per-day)
+
+        Returns:
+            Dictionary containing:
+            - totalSelfUseRate, selfSufficiencyRate (0-1 ratios)
+            - totalYield, totalConsumption, totalEnergyFromPv
+            - energyDistributions: per-bucket list
+
+        Raises:
+            SunlitAuthError: Authentication failed
+            SunlitConnectionError: Connection failed
+            SunlitApiError: API returned an error
+        """
+        try:
+            payload: dict[str, Any] = {"spaceId": int(space_id)}
+            if year is not None:
+                payload["year"] = int(year)
+            if month is not None:
+                payload["month"] = int(month)
+            response = await self._make_request(
+                "POST", API_SPACE_STATISTICS_DYNAMIC_ENERGY, json=payload
+            )
+
+            _LOGGER.debug(
+                "Space dynamic energy response for %s: %s", space_id, response
+            )
+
+            if "content" in response:
+                return response["content"]
+
+            return {}
+
+        except SunlitApiError as err:
+            _LOGGER.error(
+                "Failed to fetch energy distribution for space %s: %s",
+                space_id,
+                err,
             )
             raise
 

--- a/custom_components/sunlit/const.py
+++ b/custom_components/sunlit/const.py
@@ -32,6 +32,7 @@ API_CHARGING_BOX_CHECK_STRATEGY = "/v1.6/chargingBox/checkSpaceStrategy"
 API_BATTERY_LOCAL_MODE_CONFIG = "/v1.7/battery/updateLocalModeConfig"
 API_STRATEGY_DEVICE_STATUS = "/v1.7/strategy/device/status"
 API_TARIFF_INDEX = "/v1.6/tariff/index"
+API_SPACE_STATISTICS_DYNAMIC_ENERGY = "/v1.1/space/statistics/dynamic/energy"
 
 # Configuration keys
 CONF_EMAIL = "email"
@@ -180,6 +181,9 @@ FAMILY_SENSORS = {
     "electricity_price_high": "Electricity Price High",
     "electricity_price_low": "Electricity Price Low",
     "electricity_price_tag": "Electricity Price Tag",
+    # Energy self-consumption from statistics/dynamic/energy endpoint
+    "self_use_rate": "Self-Use Rate",
+    "self_sufficiency_rate": "Self-Sufficiency Rate",
     # Total solar production tracking
     "total_solar_energy": "Total Solar Energy",
     "total_solar_power": "Total Solar Power",
@@ -226,6 +230,8 @@ SENSOR_GROUPS = {
     # Group 2: Energy Production & Storage - Energy Dashboard compatible
     "daily_yield": SENSOR_GROUP_ENERGY,
     "lifetime_yield": SENSOR_GROUP_ENERGY,
+    "self_use_rate": SENSOR_GROUP_ENERGY,
+    "self_sufficiency_rate": SENSOR_GROUP_ENERGY,
     "total_solar_energy": SENSOR_GROUP_ENERGY,
     "total_grid_export_energy": SENSOR_GROUP_ENERGY,
     "daily_grid_export_energy": SENSOR_GROUP_ENERGY,

--- a/custom_components/sunlit/coordinators/family.py
+++ b/custom_components/sunlit/coordinators/family.py
@@ -113,6 +113,9 @@ class SunlitFamilyCoordinator(DataUpdateCoordinator):
             # Fetch dynamic electricity tariff / pricing
             await self._fetch_tariff(family_data)
 
+            # Fetch energy self-consumption rates
+            await self._fetch_energy_distribution(family_data)
+
             # Fetch current strategy
             await self._fetch_current_strategy(family_data)
 
@@ -254,6 +257,30 @@ class SunlitFamilyCoordinator(DataUpdateCoordinator):
                     family_data["electricity_price_tag"] = price.get("priceTag")
         except Exception as err:
             _LOGGER.debug("Could not fetch tariff index: %s", err)
+
+    async def _fetch_energy_distribution(self, family_data: dict) -> None:
+        """Fetch energy self-use / self-sufficiency rates for the current month.
+
+        These ratios are not derivable from the cumulative sensors (they need
+        consumption data), unlike period generation/earnings totals which HA's
+        statistics engine derives itself (see issue #169).
+        """
+        try:
+            now = datetime.now()
+            energy = await self.api_client.fetch_space_statistics_dynamic_energy(
+                self.family_id, year=now.year, month=now.month
+            )
+            if energy:
+                self_use = energy.get("totalSelfUseRate")
+                if self_use is not None:
+                    family_data["self_use_rate"] = round(self_use * 100, 1)
+                self_sufficiency = energy.get("selfSufficiencyRate")
+                if self_sufficiency is not None:
+                    family_data["self_sufficiency_rate"] = round(
+                        self_sufficiency * 100, 1
+                    )
+        except Exception as err:
+            _LOGGER.debug("Could not fetch energy distribution: %s", err)
 
     async def _fetch_current_strategy(self, family_data: dict) -> None:
         """Fetch current strategy."""

--- a/custom_components/sunlit/entities/helpers.py
+++ b/custom_components/sunlit/entities/helpers.py
@@ -114,6 +114,8 @@ def get_state_class_for_sensor(key: str) -> SensorStateClass | None:
         "electricity_price_avg",
         "electricity_price_high",
         "electricity_price_low",
+        "self_use_rate",
+        "self_sufficiency_rate",
     ]:
         return SensorStateClass.MEASUREMENT
     return None
@@ -160,7 +162,7 @@ def get_unit_for_sensor(key: str) -> str | None:
         return UnitOfEnergy.KILO_WATT_HOUR
     elif (
         "soc" in key.lower() or "battery_level" in key or "average_battery_level" in key
-    ):
+    ) or key in ("self_use_rate", "self_sufficiency_rate"):
         return PERCENTAGE
     elif key in (
         "electricity_price",
@@ -270,6 +272,11 @@ def get_icon_for_sensor(key: str, device_type: str = None) -> str | None:
     # Earnings
     elif "earnings" in key:
         return "mdi:cash"
+    # Self-consumption rates
+    elif key == "self_use_rate":
+        return "mdi:solar-power-variant"
+    elif key == "self_sufficiency_rate":
+        return "mdi:home-percent"
     # Electricity price (dynamic tariff)
     elif key == "electricity_price_tag":
         return "mdi:tag-outline"

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -391,6 +391,38 @@ async def test_fetch_space_statistics_static_success(api_client, mock_session):
 
 
 @pytest.mark.asyncio
+async def test_fetch_space_statistics_dynamic_energy_success(api_client, mock_session):
+    """Test fetching energy distribution / self-consumption rates."""
+    setup_mock_response(
+        mock_session,
+        200,
+        {
+            "code": 0,
+            "message": {"DE": "Ok"},
+            "content": {
+                "totalYield": 29.435,
+                "totalConsumption": 0,
+                "totalSelfUseRate": 1.0,
+                "selfSufficiencyRate": 0.85,
+                "energyDistributions": [{"key": 1, "yield": 1.231}],
+            },
+        },
+    )
+
+    data = await api_client.fetch_space_statistics_dynamic_energy(34038, year=2026, month=5)
+
+    assert data["totalSelfUseRate"] == 1.0
+    assert data["selfSufficiencyRate"] == 0.85
+
+    mock_session.request.assert_called_once()
+    call_args = mock_session.request.call_args
+    assert call_args[0][0] == "POST"
+    assert "/v1.1/space/statistics/dynamic/energy" in call_args[0][1]
+    assert call_args[1]["json"] == {"spaceId": 34038, "year": 2026, "month": 5}
+    assert call_args[1]["headers"]["Authorization"] == "Bearer test_token"
+
+
+@pytest.mark.asyncio
 async def test_update_battery_local_mode_success(api_client, mock_session):
     """Test enabling/disabling battery local mode (control endpoint)."""
     setup_mock_response(

--- a/tests/test_family_coordinator.py
+++ b/tests/test_family_coordinator.py
@@ -48,6 +48,11 @@ async def test_family_coordinator_update_success(
             "hour": 16,
         },
     }
+    api_client.fetch_space_statistics_dynamic_energy.return_value = {
+        "totalSelfUseRate": 1.0,
+        "selfSufficiencyRate": 0.85,
+        "totalConsumption": 0,
+    }
 
     coordinator = SunlitFamilyCoordinator(
         hass,
@@ -97,11 +102,16 @@ async def test_family_coordinator_update_success(
     assert family_data["electricity_price_low"] == -7.59
     assert family_data["electricity_price_tag"] == "CHEAP"
 
+    # Check energy self-consumption rates (ratios × 100)
+    assert family_data["self_use_rate"] == 100.0
+    assert family_data["self_sufficiency_rate"] == 85.0
+
     # Verify API calls
     api_client.fetch_space_index.assert_called_once_with("34038")
     api_client.fetch_space_soc.assert_called_once_with("34038")
     api_client.fetch_space_statistics_static.assert_called_once_with("34038")
     api_client.fetch_tariff_index.assert_called_once_with("34038")
+    api_client.fetch_space_statistics_dynamic_energy.assert_called_once()
     api_client.fetch_strategy_device_status.assert_called_once_with("34038")
     api_client.fetch_space_current_strategy.assert_called_once_with("34038")
     api_client.get_charging_box_strategy.assert_called_once_with("34038")
@@ -119,6 +129,9 @@ async def test_family_coordinator_partial_failure(
     api_client.fetch_space_statistics_static.side_effect = Exception("Stats API failed")
     api_client.fetch_strategy_device_status.side_effect = Exception("Status API failed")
     api_client.fetch_tariff_index.side_effect = Exception("Tariff API failed")
+    api_client.fetch_space_statistics_dynamic_energy.side_effect = Exception(
+        "Energy API failed"
+    )
     api_client.fetch_space_current_strategy.side_effect = Exception("Strategy API failed")
     api_client.get_charging_box_strategy.side_effect = Exception("Charging box API failed")
 
@@ -147,6 +160,7 @@ async def test_family_coordinator_partial_failure(
     assert "lifetime_yield" not in family_data
     assert "battery_local_mode_enabled" not in family_data
     assert "electricity_price" not in family_data
+    assert "self_use_rate" not in family_data
 
 
 async def test_family_coordinator_complete_failure(
@@ -161,6 +175,9 @@ async def test_family_coordinator_complete_failure(
     api_client.fetch_space_statistics_static.side_effect = Exception("Stats API failed")
     api_client.fetch_strategy_device_status.side_effect = Exception("Status API failed")
     api_client.fetch_tariff_index.side_effect = Exception("Tariff API failed")
+    api_client.fetch_space_statistics_dynamic_energy.side_effect = Exception(
+        "Energy API failed"
+    )
     api_client.fetch_space_current_strategy.side_effect = Exception("Strategy API failed")
     api_client.get_charging_box_strategy.side_effect = Exception("Charging box API failed")
 

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -382,3 +382,15 @@ class TestElectricityPriceSensors:
         assert get_state_class_for_sensor("electricity_price_tag") is None
         assert get_unit_for_sensor("electricity_price_tag") is None
         assert get_icon_for_sensor("electricity_price_tag") == "mdi:tag-outline"
+
+
+class TestSelfConsumptionSensors:
+    """Test classification of energy self-consumption sensors (issue #168)."""
+
+    @pytest.mark.parametrize("key", ["self_use_rate", "self_sufficiency_rate"])
+    def test_rates(self, key):
+        """Self-use / self-sufficiency are % measurements, no device class."""
+        assert get_device_class_for_sensor(key) is None
+        assert get_state_class_for_sensor(key) == SensorStateClass.MEASUREMENT
+        assert get_unit_for_sensor(key) == PERCENTAGE
+        assert get_icon_for_sensor(key) is not None


### PR DESCRIPTION
## Summary

Adds the **non-derivable** energy ratios from `POST /v1.1/space/statistics/dynamic/energy`
as family-hub `%` sensors (current month), per the #169 decision:

- **Self-Use Rate** — `totalSelfUseRate × 100`
- **Self-Sufficiency Rate** — `selfSufficiencyRate × 100`

Period generation/earnings **totals are intentionally not added** — HA's
Statistics engine / Energy Dashboard / `utility_meter` derive those from the
existing `lifetime_yield` cumulative sensor (see #169). Only the ratios HA can't
compute itself are exposed.

## Changes
- `api_client.fetch_space_statistics_dynamic_energy(space_id, year, month)` (optional granularity).
- Family coordinator fetches the current month's rates (graceful on failure / null).
- `helpers`: `%` unit + `measurement` state class + icons.
- Tests: api_client fetch, coordinator fields (present/absent), helper classification.

`%` sensors use no device_class (HA has no ratio device class). Note: on a
meter-less BK215, consumption is 0 so both rates read ~100%.

## Test plan
- [x] Pre-commit (ruff/format/isort) passes.
- [x] Endpoint shape verified live against `api.sunenergyxt.com`.
- [ ] CI `pytest` — not runnable locally.

Closes #168
🤖 Generated with [Claude Code](https://claude.com/claude-code)