### PR TITLE
fix: tolerate null heaterStatusList in family coordinator

### DIFF
--- a/custom_components/sunlit/coordinators/family.py
+++ b/custom_components/sunlit/coordinators/family.py
@@ -157,8 +157,10 @@ class SunlitFamilyCoordinator(DataUpdateCoordinator):
                 family_data["total_input_power"] = battery_data.get("inputPower")
                 family_data["total_output_power"] = battery_data.get("outputPower")
 
-                # Heater status
-                heater_status = battery_data.get("heaterStatusList", [])
+                # Heater status. Use `or []` (not a .get default): the API can
+                # return "heaterStatusList": null, which would otherwise yield
+                # None and break iteration (UpdateFailed for the whole family).
+                heater_status = battery_data.get("heaterStatusList") or []
                 for idx, status in enumerate(heater_status, 1):
                     family_data[f"battery_heater_{idx}"] = status
 

--- a/tests/test_family_coordinator.py
+++ b/tests/test_family_coordinator.py
@@ -176,6 +176,45 @@ async def test_family_coordinator_complete_failure(
     assert data == {"family": {}}
 
 
+async def test_family_coordinator_null_heater_status(
+    hass: HomeAssistant,
+    enable_custom_integrations,
+):
+    """A null heaterStatusList must not crash the coordinator (regression).
+
+    The API can return ``"heaterStatusList": null``; iterating it directly
+    raised 'NoneType' object is not iterable and failed the whole family.
+    """
+    api_client = AsyncMock()
+    api_client.fetch_space_index.return_value = {
+        "battery": {
+            "deviceStatus": "Online",
+            "batteryLevel": 80,
+            "heaterStatusList": None,
+        },
+    }
+    # Keep this test focused on _process_space_index; skip the rest.
+    for method in (
+        "fetch_device_list",
+        "fetch_space_soc",
+        "fetch_space_statistics_static",
+        "fetch_strategy_device_status",
+        "fetch_tariff_index",
+        "fetch_space_current_strategy",
+        "get_charging_box_strategy",
+    ):
+        getattr(api_client, method).side_effect = Exception("skip")
+
+    coordinator = SunlitFamilyCoordinator(hass, api_client, "34038", "Test Family")
+
+    # Must not raise UpdateFailed.
+    data = await coordinator._async_update_data()
+
+    family_data = data["family"]
+    assert family_data["average_battery_level"] == 80
+    assert "battery_heater_1" not in family_data
+
+
 # Tests for Issue #62 - Negative daily value validation
 async def test_family_coordinator_negative_daily_yield_clamped(
     hass: HomeAssistant,


### PR DESCRIPTION
## Bug

A user hit, on every update:

```
Error fetching family data for Garage: 'NoneType' object is not iterable
```

`space/index` can return `"heaterStatusList": null`. `dict.get(key, [])`
returns its default **only when the key is absent**, so a present-but-`null`
value gives `None`, and `enumerate(None)` raises. Because `_process_space_index`
isn't individually wrapped, this fails the **entire** family coordinator
(`UpdateFailed` → all family sensors go unavailable).

## Fix

```python
heater_status = battery_data.get("heaterStatusList") or []
```

`or []` handles both absent and `null`. Audited the coordinators — this was the
only unguarded `.get(k, [])`-then-iterate (the `inverterSn` join is already
guarded by `if ...:` and wrapped in try/except).

Adds a regression test (`heaterStatusList: None` → no crash, no heater entities).

## Test plan
- [x] Pre-commit passes; regression test added.
- [ ] CI `pytest`.