### PR TITLE
feat(sensors): surface device-detail diagnostics (#159)

### DIFF
--- a/custom_components/sunlit/binary_sensor.py
+++ b/custom_components/sunlit/binary_sensor.py
@@ -129,6 +129,17 @@ DEVICE_BINARY_SENSORS = {
         "icon": "mdi:power",
         "inverted": True,  # When "off" is True, binary sensor should be False
     },
+    # Diagnostics from device details (#159)
+    "ota_in_progress": {
+        "name": "Firmware Update In Progress",
+        "device_class": BinarySensorDeviceClass.UPDATE,
+        "icon": "mdi:cellphone-arrow-down",
+    },
+    "has_valid_meter": {
+        "name": "Valid Meter",
+        "device_class": BinarySensorDeviceClass.CONNECTIVITY,
+        "icon": "mdi:meter-electric",
+    },
 }
 
 

--- a/custom_components/sunlit/const.py
+++ b/custom_components/sunlit/const.py
@@ -120,6 +120,9 @@ BATTERY_SENSORS = {
     "batteryMppt2InCur": "MPPT2 Current",
     "batteryMppt2InPower": "MPPT2 Power",
     "batteryMppt2Energy": "MPPT2 Total Energy",
+    # Diagnostics from device details (#159)
+    "wifi_ssid": "WiFi SSID",
+    "system_status": "System Status",
 }
 
 # Battery module specific sensors (will be created for each module 1, 2, 3)

--- a/custom_components/sunlit/coordinators/device.py
+++ b/custom_components/sunlit/coordinators/device.py
@@ -345,17 +345,22 @@ class SunlitDeviceCoordinator(DataUpdateCoordinator):
         else:
             data["module_count"] = fallback_module_count
 
-        # Local-mode capability and current state for the control switch (#160).
-        # Sourced from device details; only meaningful while the battery is online.
+        # Device details (only meaningful while online): local-mode flags for the
+        # control switch (#160) plus diagnostic fields (#159).
         if device.get("status") == "Online":
             try:
                 details = await self.api_client.fetch_device_details(device_id)
                 if details.get("supportLocalMode"):
                     data["support_local_mode"] = True
                     data["local_mode_enabled"] = details.get("localModeEnabled")
+                # Diagnostics (#159)
+                data["wifi_ssid"] = details.get("ssid")
+                data["system_status"] = details.get("systemMultiStatus")
+                data["ota_in_progress"] = details.get("otaInProgress")
+                data["has_valid_meter"] = details.get("hasValidMeter")
             except Exception as err:
                 _LOGGER.debug(
-                    "Could not fetch local-mode status for device %s: %s",
+                    "Could not fetch device details for device %s: %s",
                     device_id,
                     err,
                 )

--- a/custom_components/sunlit/entities/helpers.py
+++ b/custom_components/sunlit/entities/helpers.py
@@ -194,6 +194,12 @@ def get_icon_for_sensor(key: str, device_type: str = None) -> str | None:
             return "mdi:timer-sand"
         elif "discharge" in key.lower():
             return "mdi:timer-sand-empty"
+    # Device diagnostics (#159) — before device_type branches so battery
+    # devices don't fall through to the generic battery icon.
+    elif key == "wifi_ssid":
+        return "mdi:wifi"
+    elif key == "system_status":
+        return "mdi:information-outline"
     # Solar/Inverter related
     elif device_type == "YUNENG_MICRO_INVERTER" or "generation" in key:
         return "mdi:solar-power"

--- a/tests/test_device_coordinator.py
+++ b/tests/test_device_coordinator.py
@@ -48,6 +48,10 @@ async def test_device_coordinator_update_success(
         "deviceSn": "dcbdccbffe3d",
         "supportLocalMode": True,
         "localModeEnabled": True,
+        "ssid": "WLAN-2TXFBD",
+        "systemMultiStatus": "Drei Batterien parallel",
+        "otaInProgress": False,
+        "hasValidMeter": False,
     }
 
     coordinator = SunlitDeviceCoordinator(
@@ -90,6 +94,12 @@ async def test_device_coordinator_update_success(
     # Local-mode control state (issue #160)
     assert battery["support_local_mode"] is True
     assert battery["local_mode_enabled"] is True
+
+    # Device-detail diagnostics (issue #159)
+    assert battery["wifi_ssid"] == "WLAN-2TXFBD"
+    assert battery["system_status"] == "Drei Batterien parallel"
+    assert battery["ota_in_progress"] is False
+    assert battery["has_valid_meter"] is False
 
     # Check aggregates
     aggregates = data["aggregates"]

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -394,3 +394,24 @@ class TestSelfConsumptionSensors:
         assert get_state_class_for_sensor(key) == SensorStateClass.MEASUREMENT
         assert get_unit_for_sensor(key) == PERCENTAGE
         assert get_icon_for_sensor(key) is not None
+
+
+class TestDeviceDiagnosticSensors:
+    """Test classification of device-detail diagnostic sensors (issue #159)."""
+
+    def test_text_diagnostics_have_no_device_class(self):
+        """ssid / system status are plain text sensors."""
+        for key in ("wifi_ssid", "system_status"):
+            assert get_device_class_for_sensor(key) is None
+            assert get_state_class_for_sensor(key) is None
+            assert get_unit_for_sensor(key) is None
+
+    def test_diagnostic_icons_resolve_for_battery_device(self):
+        """Icons must resolve before the battery device_type branch."""
+        assert (
+            get_icon_for_sensor("wifi_ssid", "ENERGY_STORAGE_BATTERY") == "mdi:wifi"
+        )
+        assert (
+            get_icon_for_sensor("system_status", "ENERGY_STORAGE_BATTERY")
+            == "mdi:information-outline"
+        )


### PR DESCRIPTION
## Summary

Surfaces **net-new** battery diagnostics from `GET /device/{id}` (already fetched
by the device coordinator for online batteries since #160):

| Entity | Type |
|---|---|
| WiFi SSID (`wifi_ssid`) | text sensor |
| System Status (`system_status`, e.g. "Drei Batterien parallel") | text sensor |
| Firmware Update In Progress (`ota_in_progress`) | binary (`update`) |
| Valid Meter (`has_valid_meter`) | binary (`connectivity`) |

Deliberately **skips** fields already exposed: SOC limits (family-level via
`space/soc`), firmware/hardware versions (in `device_info`), and `localModeEnabled`
(the #160 switch) — to avoid duplication.

## Changes
- `coordinators/device.py`: capture the fields in the existing details fetch.
- `const.BATTERY_SENSORS` (text) + `binary_sensor.DEVICE_BINARY_SENSORS` (binary).
- `helpers`: SSID/status icons placed **before** the battery `device_type` icon branch (otherwise they'd fall through to the generic battery icon).
- Tests: device-coordinator fields + helper classification/icons.

## Test plan
- [x] Pre-commit passes.
- [x] Field names verified against the live `GET /device/{id}` capture.
- [ ] CI `pytest`.

Closes #159
🤖 Generated with [Claude Code](https://claude.com/claude-code)