### PR TITLE
docs: surface SunEnergyXT rebrand in display name and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
-# Sunlit Solar - HomeAssistant Integration
+# SunEnergyXT (previously Sunlit Solar) - HomeAssistant Integration
+
+> ℹ️ **[SunEnergyXT](https://www.sunenergyxt.com/) was previously branded Sunlit / Sunlit Solar.**
+> The hardware (BK215 battery, inverters, meters) and the underlying cloud API are
+> unchanged. This integration works with both the new **SunEnergyXT** and the legacy
+> **Sunlit** / **Sunlit Solar** branding and apps.
 
 > ⚠️ **EXPERIMENTAL INTEGRATION - USE AT YOUR OWN RISK**
 >
-> This is an **unofficial** custom integration for HomeAssistant to monitor Sunlit Solar systems.
-> This integration is not affiliated with, endorsed by, or supported by Sunlit.
+> This is an **unofficial** custom integration for HomeAssistant to monitor SunEnergyXT (previously Sunlit Solar) systems.
+> This integration is not affiliated with, endorsed by, or supported by SunEnergyXT / Sunlit.
 >
 > **No warranty or support is provided. Use of this integration is entirely at your own risk.**
 
 ## Overview
 
-This custom integration connects HomeAssistant to the Sunlit Solar API, enabling real-time monitoring of your solar installation including solar panels, inverters, batteries, and energy meters. It provides comprehensive sensor data for monitoring energy production, consumption, and battery status.
+This custom integration connects HomeAssistant to the SunEnergyXT (previously Sunlit Solar) API, enabling real-time monitoring of your solar installation including solar panels, inverters, batteries, and energy meters. It provides comprehensive sensor data for monitoring energy production, consumption, and battery status.
 
 ### Key Features
 

--- a/custom_components/sunlit/manifest.json
+++ b/custom_components/sunlit/manifest.json
@@ -1,6 +1,6 @@
 {
     "domain": "sunlit",
-    "name": "Sunlit REST Integration",
+    "name": "SunEnergyXT (previously Sunlit Solar)",
     "codeowners": [
         "@cedricziel"
     ],

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-    "name": "Sunlit Solar",
+    "name": "SunEnergyXT (previously Sunlit Solar)",
     "homeassistant": "2025.1.0"
 }


### PR DESCRIPTION
## What

Sunlit Solar rebranded to **SunEnergyXT** (`sunlitsolar.de` now 301-redirects to `sunenergyxt.com`; the official site has a dedicated brand-change page). This makes the integration discoverable under both the new and legacy names.

## Changes

- `manifest.json` / `hacs.json` name → `SunEnergyXT (previously Sunlit Solar)` — surfaces in HA *Add Integration* and HACS store search
- `README.md` → title, rebrand note (links sunenergyxt.com), disclaimer, overview
- `domain: "sunlit"` **left unchanged** so existing installations and entity IDs don't break

GitHub repo metadata (description + `sunenergyxt`/`bk215` topics) was also updated separately.

## Notes

- `docs:` change — does not trigger a release-please version bump; the new display name ships with the next `feat:`/`fix:` release.