### PR TITLE
feat(sensors): add latest-notification sensor (#176)

### DIFF
--- a/custom_components/sunlit/api_client.py
+++ b/custom_components/sunlit/api_client.py
@@ -17,6 +17,7 @@ from .const import (
     API_DEVICE_LIST,
     API_DEVICE_STATISTICS,
     API_FAMILY_LIST,
+    API_NOTIFICATION_LIST,
     API_SPACE_CURRENT_STRATEGY,
     API_SPACE_INDEX,
     API_SPACE_SOC,
@@ -574,6 +575,39 @@ class SunlitApiClient:
             _LOGGER.error(
                 "Failed to fetch lifetime statistics for space %s: %s", space_id, err
             )
+            raise
+
+    async def fetch_notification_list(
+        self, page: int = 0, size: int = 20
+    ) -> dict[str, Any]:
+        """Fetch the paginated notification feed for the account.
+
+        Args:
+            page: Page number (0-based)
+            size: Page size
+
+        Returns:
+            Paginated content dict with a "content" list of notification items
+            ({id, type, title, content, read, deviceSn, deviceType, space, ...}).
+
+        Raises:
+            SunlitAuthError: Authentication failed
+            SunlitConnectionError: Connection failed
+            SunlitApiError: API returned an error
+        """
+        try:
+            payload = {"page": page, "size": size}
+            response = await self._make_request(
+                "POST", API_NOTIFICATION_LIST, json=payload
+            )
+
+            if "content" in response:
+                return response["content"]
+
+            return {}
+
+        except SunlitApiError as err:
+            _LOGGER.error("Failed to fetch notification list: %s", err)
             raise
 
     async def fetch_space_statistics_dynamic_energy(

--- a/custom_components/sunlit/const.py
+++ b/custom_components/sunlit/const.py
@@ -33,6 +33,7 @@ API_BATTERY_LOCAL_MODE_CONFIG = "/v1.7/battery/updateLocalModeConfig"
 API_STRATEGY_DEVICE_STATUS = "/v1.7/strategy/device/status"
 API_TARIFF_INDEX = "/v1.6/tariff/index"
 API_SPACE_STATISTICS_DYNAMIC_ENERGY = "/v1.1/space/statistics/dynamic/energy"
+API_NOTIFICATION_LIST = "/v1.5/notification/list"
 
 # Configuration keys
 CONF_EMAIL = "email"
@@ -184,6 +185,8 @@ FAMILY_SENSORS = {
     # Energy self-consumption from statistics/dynamic/energy endpoint
     "self_use_rate": "Self-Use Rate",
     "self_sufficiency_rate": "Self-Sufficiency Rate",
+    # Latest notification from notification/list endpoint
+    "latest_notification": "Latest Notification",
     # Total solar production tracking
     "total_solar_energy": "Total Solar Energy",
     "total_solar_power": "Total Solar Power",
@@ -270,6 +273,7 @@ SENSOR_GROUPS = {
     # Group 5: System Information - Static configuration data
     "device_count": SENSOR_GROUP_INFO,
     "battery_count": SENSOR_GROUP_INFO,
+    "latest_notification": SENSOR_GROUP_INFO,
     "rated_power": SENSOR_GROUP_INFO,
     "max_output_power": SENSOR_GROUP_INFO,
     "inverter_sn_list": SENSOR_GROUP_INFO,

--- a/custom_components/sunlit/coordinators/family.py
+++ b/custom_components/sunlit/coordinators/family.py
@@ -116,6 +116,9 @@ class SunlitFamilyCoordinator(DataUpdateCoordinator):
             # Fetch energy self-consumption rates
             await self._fetch_energy_distribution(family_data)
 
+            # Fetch the latest notification for this family
+            await self._fetch_notifications(family_data)
+
             # Fetch current strategy
             await self._fetch_current_strategy(family_data)
 
@@ -283,6 +286,41 @@ class SunlitFamilyCoordinator(DataUpdateCoordinator):
                     )
         except Exception as err:
             _LOGGER.debug("Could not fetch energy distribution: %s", err)
+
+    async def _fetch_notifications(self, family_data: dict) -> None:
+        """Fetch the latest notification for this family.
+
+        The feed is account-wide; filter to this family's space and keep the
+        newest entry. Full detail is stored under latest_notification_detail
+        for the sensor's attributes.
+        """
+        try:
+            result = await self.api_client.fetch_notification_list(page=0, size=20)
+            items = (result or {}).get("content") or []
+            try:
+                fid = int(self.family_id)
+            except (TypeError, ValueError):
+                fid = None
+            family_items = [
+                n
+                for n in items
+                if fid is None or (n.get("space") or {}).get("id") == fid
+            ]
+            if family_items:
+                latest = max(family_items, key=lambda n: n.get("createDate") or 0)
+                family_data["latest_notification"] = latest.get("title")
+                family_data["latest_notification_detail"] = {
+                    "id": latest.get("id"),
+                    "content": latest.get("content"),
+                    "type": latest.get("type"),
+                    "device_sn": latest.get("deviceSn"),
+                    "device_type": latest.get("readableDeviceType")
+                    or latest.get("deviceType"),
+                    "read": latest.get("read"),
+                    "create_date": latest.get("createDate"),
+                }
+        except Exception as err:
+            _LOGGER.debug("Could not fetch notifications: %s", err)
 
     async def _fetch_current_strategy(self, family_data: dict) -> None:
         """Fetch current strategy."""

--- a/custom_components/sunlit/entities/family_sensor.py
+++ b/custom_components/sunlit/entities/family_sensor.py
@@ -182,4 +182,14 @@ class SunlitFamilySensor(CoordinatorEntity, SensorEntity):
                     )
                 attrs["history"] = formatted_history
 
+        # Add notification detail if available
+        if (
+            self.entity_description.key == "latest_notification"
+            and self.coordinator.data
+            and "family" in self.coordinator.data
+        ):
+            detail = self.coordinator.data["family"].get("latest_notification_detail")
+            if detail:
+                attrs.update(detail)
+
         return attrs

--- a/custom_components/sunlit/entities/helpers.py
+++ b/custom_components/sunlit/entities/helpers.py
@@ -277,6 +277,9 @@ def get_icon_for_sensor(key: str, device_type: str = None) -> str | None:
         return "mdi:solar-power-variant"
     elif key == "self_sufficiency_rate":
         return "mdi:home-percent"
+    # Latest notification
+    elif key == "latest_notification":
+        return "mdi:bell"
     # Electricity price (dynamic tariff)
     elif key == "electricity_price_tag":
         return "mdi:tag-outline"

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -423,6 +423,43 @@ async def test_fetch_space_statistics_dynamic_energy_success(api_client, mock_se
 
 
 @pytest.mark.asyncio
+async def test_fetch_notification_list_success(api_client, mock_session):
+    """Test fetching the paginated notification feed."""
+    setup_mock_response(
+        mock_session,
+        200,
+        {
+            "code": 0,
+            "message": {"DE": "Ok"},
+            "content": {
+                "content": [
+                    {
+                        "id": 5851069,
+                        "title": "Speicher beginnt das Heizen",
+                        "read": True,
+                        "space": {"id": 34038, "name": "Garage"},
+                    }
+                ],
+                "totalElements": 1,
+                "empty": False,
+            },
+        },
+    )
+
+    data = await api_client.fetch_notification_list(page=0, size=20)
+
+    assert data["content"][0]["id"] == 5851069
+    assert data["totalElements"] == 1
+
+    mock_session.request.assert_called_once()
+    call_args = mock_session.request.call_args
+    assert call_args[0][0] == "POST"
+    assert "/v1.5/notification/list" in call_args[0][1]
+    assert call_args[1]["json"] == {"page": 0, "size": 20}
+    assert call_args[1]["headers"]["Authorization"] == "Bearer test_token"
+
+
+@pytest.mark.asyncio
 async def test_update_battery_local_mode_success(api_client, mock_session):
     """Test enabling/disabling battery local mode (control endpoint)."""
     setup_mock_response(

--- a/tests/test_family_coordinator.py
+++ b/tests/test_family_coordinator.py
@@ -53,6 +53,32 @@ async def test_family_coordinator_update_success(
         "selfSufficiencyRate": 0.85,
         "totalConsumption": 0,
     }
+    api_client.fetch_notification_list.return_value = {
+        "content": [
+            {
+                "id": 1,
+                "title": "Older",
+                "createDate": 1000,
+                "space": {"id": 34038, "name": "Garage"},
+            },
+            {
+                "id": 2,
+                "title": "Speicher beginnt das Heizen",
+                "content": "Sie müssen nichts tun.",
+                "type": "push",
+                "deviceSn": "dcbdccbffe3d",
+                "read": True,
+                "createDate": 2000,
+                "space": {"id": 34038, "name": "Garage"},
+            },
+            {
+                "id": 3,
+                "title": "Other family",
+                "createDate": 3000,
+                "space": {"id": 99999, "name": "Test"},
+            },
+        ]
+    }
 
     coordinator = SunlitFamilyCoordinator(
         hass,
@@ -106,12 +132,19 @@ async def test_family_coordinator_update_success(
     assert family_data["self_use_rate"] == 100.0
     assert family_data["self_sufficiency_rate"] == 85.0
 
+    # Check latest notification (newest for THIS family; other family excluded)
+    assert family_data["latest_notification"] == "Speicher beginnt das Heizen"
+    detail = family_data["latest_notification_detail"]
+    assert detail["id"] == 2
+    assert detail["device_sn"] == "dcbdccbffe3d"
+
     # Verify API calls
     api_client.fetch_space_index.assert_called_once_with("34038")
     api_client.fetch_space_soc.assert_called_once_with("34038")
     api_client.fetch_space_statistics_static.assert_called_once_with("34038")
     api_client.fetch_tariff_index.assert_called_once_with("34038")
     api_client.fetch_space_statistics_dynamic_energy.assert_called_once()
+    api_client.fetch_notification_list.assert_called_once()
     api_client.fetch_strategy_device_status.assert_called_once_with("34038")
     api_client.fetch_space_current_strategy.assert_called_once_with("34038")
     api_client.get_charging_box_strategy.assert_called_once_with("34038")
@@ -132,6 +165,7 @@ async def test_family_coordinator_partial_failure(
     api_client.fetch_space_statistics_dynamic_energy.side_effect = Exception(
         "Energy API failed"
     )
+    api_client.fetch_notification_list.side_effect = Exception("Notif API failed")
     api_client.fetch_space_current_strategy.side_effect = Exception("Strategy API failed")
     api_client.get_charging_box_strategy.side_effect = Exception("Charging box API failed")
 
@@ -161,6 +195,7 @@ async def test_family_coordinator_partial_failure(
     assert "battery_local_mode_enabled" not in family_data
     assert "electricity_price" not in family_data
     assert "self_use_rate" not in family_data
+    assert "latest_notification" not in family_data
 
 
 async def test_family_coordinator_complete_failure(
@@ -178,6 +213,7 @@ async def test_family_coordinator_complete_failure(
     api_client.fetch_space_statistics_dynamic_energy.side_effect = Exception(
         "Energy API failed"
     )
+    api_client.fetch_notification_list.side_effect = Exception("Notif API failed")
     api_client.fetch_space_current_strategy.side_effect = Exception("Strategy API failed")
     api_client.get_charging_box_strategy.side_effect = Exception("Charging box API failed")
 


### PR DESCRIPTION
## Summary

Surfaces the notification feed (`POST /v1.5/notification/list`) as a family-hub
**Latest Notification** sensor (the content behind #158's unread counts):

- **state** = newest notification title for this family
- **attributes** = `id`, `content`, `type`, `device_sn`, `device_type`, `read`, `create_date`

The feed is account-wide, so the coordinator filters by `space.id` and keeps the
newest entry per family.

## Changes
- `api_client.fetch_notification_list(page, size)`.
- Family coordinator `_fetch_notifications` (graceful on failure; stores detail under `latest_notification_detail`).
- `family_sensor.extra_state_attributes` exposes the detail for `latest_notification`.
- `const` (sensor + info group) + helper icon.
- Tests: api_client fetch; coordinator picks newest + excludes other families; absent on failure.

## Notes
- Account-scoped feed is fetched once per family per cycle; fine for the common single-family case.
- Inbox-management endpoints (read/delete) remain out of scope (documented in spec only).

## Test plan
- [x] Pre-commit passes; shapes verified against the live `notification/list` capture.
- [ ] CI `pytest`.

Closes #176
🤖 Generated with [Claude Code](https://claude.com/claude-code)