### PR TITLE
ci: attach openapi.yaml to published releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v5
+        id: release
         with:
           # this assumes that you have created a personal access token
           # (PAT) and configured it as a GitHub action secret named
@@ -22,3 +23,13 @@ jobs:
 
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # When a release is published, attach the OpenAPI spec as a release asset.
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created }}
+
+      - name: Attach OpenAPI spec to the release
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ steps.release.outputs.tag_name }}" openapi.yaml --clobber


### PR DESCRIPTION
## Summary

When release-please publishes a release, attach **`openapi.yaml`** as a release
asset so users/consumers can download the versioned API reference straight from
the GitHub Release.

## How
- Gave the `release-please-action` step an `id: release`.
- Added two steps gated on `${{ steps.release.outputs.release_created }}`:
  - `actions/checkout@v4` (to get `openapi.yaml` on disk)
  - `gh release upload "${{ steps.release.outputs.tag_name }}" openapi.yaml --clobber`
- Uses the built-in `github.token` (the workflow already has `contents: write`); `--clobber` keeps re-runs idempotent.

No effect on PR/CI runs — only fires on the push-to-main that creates a release.