### PR TITLE
feat: backfill historical statistics via dynamic/earning (#180)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,12 +322,19 @@ To integrate with HomeAssistant's Energy Dashboard:
 1. Go to **Settings** → **Dashboards** → **Energy**
 2. Under **Solar Panels**, click **Add Solar Production**
 3. Select the family **Lifetime Yield** sensor (`sensor.sunlit_[family]_lifetime_yield`) —
-   it is a cumulative `total_increasing` kWh sensor, so HA derives daily/monthly/yearly
-   automatically (no Riemann-sum helper needed for solar).
+   a cumulative kWh series, so HA derives daily/monthly/yearly automatically
+   (no Riemann-sum helper needed for solar).
+
+> **Backfill pre-install history:** the integration **owns** the long-term
+> statistics for `lifetime_yield` and `lifetime_earnings` (they have no
+> `state_class`), so it can fill in history from the cloud. Run **Developer
+> Tools → Actions → _Sunlit: Import historical statistics_** (`sunlit.import_history`)
+> once and years of past generation & earnings appear on these same sensors as
+> one continuous series. The import is idempotent — safe to re-run. Between
+> imports the series is kept current automatically (hourly).
 
 > Tip: for per-period figures (this month, this year) use a HA **Statistics** card or a
-> **`utility_meter`** helper on `lifetime_yield` — the integration deliberately does not
-> ship separate month/year total sensors.
+> **`utility_meter`** helper on `lifetime_yield`.
 
 ### Grid Consumption
 

--- a/custom_components/sunlit/__init__.py
+++ b/custom_components/sunlit/__init__.py
@@ -6,7 +6,7 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .api_client import SunlitApiClient
@@ -23,6 +23,7 @@ from .const import (
     OPT_SOC_THRESHOLD_CRITICAL_LOW,
     OPT_SOC_THRESHOLD_HIGH,
     OPT_SOC_THRESHOLD_LOW,
+    SERVICE_IMPORT_HISTORY,
 )
 from .coordinators import (
     SunlitDeviceCoordinator,
@@ -33,6 +34,7 @@ from .coordinators import (
 )
 from .event_manager import SunlitEventManager
 from .local.manager import LocalChannelManager
+from .statistics import async_import_family_history
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -212,12 +214,43 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "local_manager": local_manager,
     }
 
+    _async_register_services(hass)
+
     # Add update listener for options changes
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
+
+def _async_register_services(hass: HomeAssistant) -> None:
+    """Register integration-wide services (only once)."""
+    if hass.services.has_service(DOMAIN, SERVICE_IMPORT_HISTORY):
+        return
+
+    async def _handle_import_history(call: ServiceCall) -> None:
+        """Backfill historical long-term statistics for all configured spaces."""
+        total = 0
+        for entry_data in hass.data.get(DOMAIN, {}).values():
+            api_client = entry_data["api_client"]
+            for family in entry_data["coordinators"].values():
+                family_coordinator = family["family"]
+                try:
+                    total += await async_import_family_history(
+                        hass,
+                        api_client,
+                        family_coordinator.family_id,
+                        family_coordinator.family_name,
+                    )
+                except Exception:
+                    _LOGGER.exception(
+                        "Failed to import historical statistics for space %s",
+                        family_coordinator.family_id,
+                    )
+        _LOGGER.info("Historical statistics import complete: %s day(s) total", total)
+
+    hass.services.async_register(DOMAIN, SERVICE_IMPORT_HISTORY, _handle_import_history)
 
 
 async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -233,5 +266,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         local_manager = entry_data.get("local_manager")
         if local_manager is not None:
             await local_manager.async_stop()
+
+        # Remove integration-wide services once the last entry is gone
+        if not hass.data[DOMAIN] and hass.services.has_service(
+            DOMAIN, SERVICE_IMPORT_HISTORY
+        ):
+            hass.services.async_remove(DOMAIN, SERVICE_IMPORT_HISTORY)
 
     return unload_ok

--- a/custom_components/sunlit/__init__.py
+++ b/custom_components/sunlit/__init__.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_track_time_change
 
 from .api_client import SunlitApiClient
 from .const import (
@@ -34,7 +36,10 @@ from .coordinators import (
 )
 from .event_manager import SunlitEventManager
 from .local.manager import LocalChannelManager
-from .statistics import async_import_family_history
+from .statistics import (
+    async_import_family_history,
+    async_record_family_live_statistics,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -216,10 +221,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     _async_register_services(hass)
 
+    # The lifetime_yield / lifetime_earnings sensors have no state_class — the
+    # integration owns their long-term statistics. Append the live cumulative
+    # value hourly (historical periods come from the `sunlit.import_history`
+    # service), and seed one point right after setup so the entities are
+    # immediately selectable in the Energy Dashboard.
+    @callback
+    def _record_live_statistics() -> None:
+        entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+        if not entry_data:
+            return
+        for family in entry_data["coordinators"].values():
+            async_record_family_live_statistics(hass, family["family"])
+
+    @callback
+    def _record_hourly_statistics(now: datetime) -> None:
+        _record_live_statistics()
+
+    entry.async_on_unload(
+        async_track_time_change(hass, _record_hourly_statistics, minute=0, second=0)
+    )
+
     # Add update listener for options changes
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Seed an initial statistics point now that the entities exist.
+    _record_live_statistics()
 
     return True
 

--- a/custom_components/sunlit/api_client.py
+++ b/custom_components/sunlit/api_client.py
@@ -22,6 +22,7 @@ from .const import (
     API_SPACE_CURRENT_STRATEGY,
     API_SPACE_INDEX,
     API_SPACE_SOC,
+    API_SPACE_STATISTICS_DYNAMIC_EARNING,
     API_SPACE_STATISTICS_DYNAMIC_ENERGY,
     API_SPACE_STATISTICS_STATIC,
     API_SPACE_STRATEGY_HISTORY,
@@ -662,6 +663,70 @@ class SunlitApiClient:
         except SunlitApiError as err:
             _LOGGER.error(
                 "Failed to fetch energy distribution for space %s: %s",
+                space_id,
+                err,
+            )
+            raise
+
+    async def fetch_space_statistics_dynamic_earning(
+        self,
+        space_id: str | int,
+        year: int | None = None,
+        month: int | None = None,
+    ) -> dict[str, Any]:
+        """Fetch generation & earnings for a space, with selectable granularity.
+
+        The granularity follows the optional year/month arguments (see
+        openapi.yaml). The per-bucket ``key`` changes meaning accordingly:
+
+        - no year/month -> per-year buckets (``key`` = year), all-time
+        - year only      -> per-month buckets (``key`` = month 1-12)
+        - year + month   -> per-day buckets (``key`` = day of month 1-31)
+
+        Args:
+            space_id: The space/family ID
+            year: Optional year (selects per-month or, with month, per-day)
+            month: Optional month 1-12 (requires year; yields per-day)
+
+        Returns:
+            Dictionary containing:
+            - totalPowerGeneration: period generation in kWh
+            - totalEarnings: {earnings, currency}
+            - powerEarningsList: per-bucket
+              [{key, totalPowerGeneration, totalEarnings, currency}]
+            - chargingEnergyList: per-bucket [{key, chargingEnergy}]
+
+        Raises:
+            SunlitAuthError: Authentication failed
+            SunlitConnectionError: Connection failed
+            SunlitApiError: API returned an error
+        """
+        try:
+            payload: dict[str, Any] = {"spaceId": int(space_id)}
+            if year is not None:
+                payload["year"] = int(year)
+            if month is not None:
+                payload["month"] = int(month)
+            response = await self._make_request(
+                "POST", API_SPACE_STATISTICS_DYNAMIC_EARNING, json=payload
+            )
+
+            _LOGGER.debug(
+                "Space dynamic earning response for %s (year=%s, month=%s): %s",
+                space_id,
+                year,
+                month,
+                response,
+            )
+
+            if "content" in response:
+                return response["content"]
+
+            return {}
+
+        except SunlitApiError as err:
+            _LOGGER.error(
+                "Failed to fetch earnings for space %s: %s",
                 space_id,
                 err,
             )

--- a/custom_components/sunlit/const.py
+++ b/custom_components/sunlit/const.py
@@ -39,7 +39,11 @@ API_RABOT_DAY_PRICE = "/v1.6/rabot/day/price"
 API_TARIFF_STRATEGY_ADD = "/v1.6/tariffStrategy/add"
 API_STRATEGY_SETTING_DETAIL = "/v1.8/strategy/setting/detail"
 API_SPACE_STATISTICS_DYNAMIC_ENERGY = "/v1.1/space/statistics/dynamic/energy"
+API_SPACE_STATISTICS_DYNAMIC_EARNING = "/v1.1/space/statistics/dynamic/earning"
 API_NOTIFICATION_LIST = "/v1.5/notification/list"
+
+# Services
+SERVICE_IMPORT_HISTORY = "import_history"
 
 # Configuration keys
 CONF_EMAIL = "email"

--- a/custom_components/sunlit/entities/helpers.py
+++ b/custom_components/sunlit/entities/helpers.py
@@ -124,10 +124,15 @@ def get_state_class_for_sensor(key: str) -> SensorStateClass | None:
     # Stored energy fluctuates (rises and falls) -> MEASUREMENT, never TOTAL*.
     if "storedenergy" in key.lower().replace("_", ""):
         return SensorStateClass.MEASUREMENT
+    # Integration-managed long-term statistics: lifetime_yield / lifetime_earnings
+    # opt OUT of the recorder's automatic statistics so the integration owns their
+    # whole series (historical backfill + ongoing). See statistics.py.
+    if key in ("lifetime_yield", "lifetime_earnings"):
+        return None
     # Monetary totals must use TOTAL — MONETARY forbids TOTAL_INCREASING. The
     # daily-resetting one (daily_earnings) carries a last_reset (see the entity's
     # last_reset property) so the midnight reset is handled correctly.
-    if key in ("lifetime_earnings", "daily_earnings"):
+    if key == "daily_earnings":
         return SensorStateClass.TOTAL
     # Energy: lifetime totals AND daily counters are modelled as TOTAL_INCREASING.
     # For the daily counters, TOTAL_INCREASING auto-detects the midnight reset
@@ -135,7 +140,6 @@ def get_state_class_for_sensor(key: str) -> SensorStateClass | None:
     # long-term statistics stay correct across the reset.
     if "energy" in key.lower() or key in (
         "total_yield",
-        "lifetime_yield",
         "daily_yield",
         "total_power_generation",
     ):

--- a/custom_components/sunlit/manifest.json
+++ b/custom_components/sunlit/manifest.json
@@ -1,6 +1,9 @@
 {
     "domain": "sunlit",
     "name": "SunEnergyXT (previously Sunlit Solar)",
+    "after_dependencies": [
+        "recorder"
+    ],
     "codeowners": [
         "@cedricziel"
     ],

--- a/custom_components/sunlit/services.yaml
+++ b/custom_components/sunlit/services.yaml
@@ -1,0 +1,7 @@
+import_history:
+  name: Import historical statistics
+  description: >-
+    Backfill historical generation and earnings from the Sunlit / SunEnergyXT
+    cloud into Home Assistant's long-term statistics, so pre-install history
+    shows up in the Energy Dashboard and Statistics cards. Safe to run more than
+    once; existing daily buckets are overwritten rather than duplicated.

--- a/custom_components/sunlit/statistics.py
+++ b/custom_components/sunlit/statistics.py
@@ -1,0 +1,221 @@
+"""Historical long-term statistics backfill for Sunlit.
+
+Home Assistant only keeps statistics from the moment a sensor starts recording.
+The cloud already holds years of generation & earnings history, exposed by the
+``/v1.1/space/statistics/dynamic/earning`` endpoint at year/month/day
+granularity. This module walks that history and injects it into HA's long-term
+statistics as *external* statistics (``sunlit:<space>_…``) so it shows up in the
+Energy Dashboard and Statistics cards without creating any entities.
+
+The import is idempotent: external statistics are keyed by ``start`` time, so
+re-running simply overwrites the same daily buckets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+import logging
+from typing import Any
+
+from homeassistant.components.recorder.models import StatisticData, StatisticMetaData
+from homeassistant.components.recorder.statistics import async_add_external_statistics
+from homeassistant.const import UnitOfEnergy
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from .api_client import SunlitApiClient
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+# ``mean_type`` (Home Assistant 2025.5+) replaced the deprecated ``has_mean``.
+# Stay compatible with the integration's documented minimum HA version.
+try:
+    from homeassistant.components.recorder.models import StatisticMeanType
+
+    _MEAN_META: dict[str, Any] = {"mean_type": StatisticMeanType.NONE}
+except ImportError:  # pragma: no cover - HA < 2025.5
+    _MEAN_META = {"has_mean": False}
+
+_DEFAULT_CURRENCY = "EUR"
+
+
+@dataclass(frozen=True)
+class DailyEarning:
+    """One day of historical generation and earnings for a space."""
+
+    date: date
+    generation_kwh: float
+    earnings: float
+    currency: str
+
+
+def _as_float(value: Any) -> float:
+    """Coerce an API value to float, defaulting to 0.0."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _as_int(value: Any) -> int | None:
+    """Coerce a bucket key to int, or None when not parseable."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _has_data(bucket: dict[str, Any]) -> bool:
+    """Return True if a year/month bucket carries any generation or earnings."""
+    return (
+        _as_float(bucket.get("totalPowerGeneration")) != 0.0
+        or _as_float(bucket.get("totalEarnings")) != 0.0
+    )
+
+
+async def async_collect_earning_history(
+    api: SunlitApiClient,
+    space_id: str | int,
+    today: date,
+) -> list[DailyEarning]:
+    """Walk the earning endpoint (year -> month -> day) into daily buckets.
+
+    Years and months without any data are skipped to avoid pointless requests,
+    and buckets in the future (relative to ``today``) are dropped so the current
+    month's not-yet-recorded days are not imported as zeros.
+    """
+    daily: list[DailyEarning] = []
+
+    year_content = await api.fetch_space_statistics_dynamic_earning(space_id)
+    for year_bucket in year_content.get("powerEarningsList") or []:
+        year = _as_int(year_bucket.get("key"))
+        if year is None or year > today.year or not _has_data(year_bucket):
+            continue
+
+        month_content = await api.fetch_space_statistics_dynamic_earning(
+            space_id, year=year
+        )
+        for month_bucket in month_content.get("powerEarningsList") or []:
+            month = _as_int(month_bucket.get("key"))
+            if month is None or not 1 <= month <= 12:
+                continue
+            if year == today.year and month > today.month:
+                continue
+            if not _has_data(month_bucket):
+                continue
+
+            day_content = await api.fetch_space_statistics_dynamic_earning(
+                space_id, year=year, month=month
+            )
+            for day_bucket in day_content.get("powerEarningsList") or []:
+                day = _as_int(day_bucket.get("key"))
+                if day is None or not 1 <= day <= 31:
+                    continue
+                try:
+                    bucket_date = date(year, month, day)
+                except ValueError:
+                    continue
+                if bucket_date > today:
+                    continue
+                daily.append(
+                    DailyEarning(
+                        date=bucket_date,
+                        generation_kwh=_as_float(
+                            day_bucket.get("totalPowerGeneration")
+                        ),
+                        earnings=_as_float(day_bucket.get("totalEarnings")),
+                        currency=(day_bucket.get("currency") or "").strip(),
+                    )
+                )
+
+    daily.sort(key=lambda item: item.date)
+    return daily
+
+
+def build_external_statistics(
+    space_id: str | int,
+    family_name: str,
+    daily: list[DailyEarning],
+    currency: str,
+) -> list[tuple[StatisticMetaData, list[StatisticData]]]:
+    """Turn daily buckets into (metadata, cumulative statistics) pairs.
+
+    Both series are cumulative sums (``has_sum``); the Energy Dashboard derives
+    each period's value from the difference of consecutive ``sum`` values.
+    """
+    energy_meta = StatisticMetaData(
+        **_MEAN_META,
+        has_sum=True,
+        name=f"{family_name} Lifetime Yield (imported history)",
+        source=DOMAIN,
+        statistic_id=f"{DOMAIN}:{space_id}_lifetime_yield",
+        unit_class="energy",
+        unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    )
+    earnings_meta = StatisticMetaData(
+        **_MEAN_META,
+        has_sum=True,
+        name=f"{family_name} Lifetime Earnings (imported history)",
+        source=DOMAIN,
+        statistic_id=f"{DOMAIN}:{space_id}_lifetime_earnings",
+        unit_class=None,
+        unit_of_measurement=currency,
+    )
+
+    energy_stats: list[StatisticData] = []
+    earnings_stats: list[StatisticData] = []
+    running_energy = 0.0
+    running_earnings = 0.0
+    for item in sorted(daily, key=lambda entry: entry.date):
+        start = dt_util.start_of_local_day(item.date)
+        running_energy += item.generation_kwh
+        running_earnings += item.earnings
+        energy_stats.append(
+            StatisticData(start=start, state=item.generation_kwh, sum=running_energy)
+        )
+        earnings_stats.append(
+            StatisticData(start=start, state=item.earnings, sum=running_earnings)
+        )
+
+    return [(energy_meta, energy_stats), (earnings_meta, earnings_stats)]
+
+
+async def async_import_family_history(
+    hass: HomeAssistant,
+    api: SunlitApiClient,
+    space_id: str | int,
+    family_name: str,
+) -> int:
+    """Backfill historical generation & earnings statistics for one space.
+
+    Returns the number of days imported.
+    """
+    today = dt_util.now().date()
+    daily = await async_collect_earning_history(api, space_id, today)
+    if not daily:
+        _LOGGER.warning(
+            "No historical earning data returned for space %s (%s)",
+            space_id,
+            family_name,
+        )
+        return 0
+
+    currency = next(
+        (item.currency for item in reversed(daily) if item.currency),
+        _DEFAULT_CURRENCY,
+    )
+    for metadata, statistics in build_external_statistics(
+        space_id, family_name, daily, currency
+    ):
+        if statistics:
+            async_add_external_statistics(hass, metadata, statistics)
+
+    _LOGGER.info(
+        "Imported %s day(s) of historical statistics for space %s (%s)",
+        len(daily),
+        space_id,
+        family_name,
+    )
+    return len(daily)

--- a/custom_components/sunlit/statistics.py
+++ b/custom_components/sunlit/statistics.py
@@ -1,27 +1,42 @@
-"""Historical long-term statistics backfill for Sunlit.
+"""Long-term statistics for Sunlit: historical backfill + ongoing import.
 
 Home Assistant only keeps statistics from the moment a sensor starts recording.
 The cloud already holds years of generation & earnings history, exposed by the
 ``/v1.1/space/statistics/dynamic/earning`` endpoint at year/month/day
-granularity. This module walks that history and injects it into HA's long-term
-statistics as *external* statistics (``sunlit:<space>_…``) so it shows up in the
-Energy Dashboard and Statistics cards without creating any entities.
+granularity.
 
-The import is idempotent: external statistics are keyed by ``start`` time, so
-re-running simply overwrites the same daily buckets.
+Rather than create a parallel ``sunlit:`` external series, this module imports
+the history **onto the integration's own entities** — ``lifetime_yield`` and
+``lifetime_earnings`` — so pre-install history appears on the exact sensors the
+user already has, as one continuous series in the Energy Dashboard and
+Statistics cards.
+
+Because those two sensors therefore opt **out** of the recorder's automatic
+statistics (no ``state_class`` — see ``entities/helpers.py``), this module owns
+their whole statistics series: a one-shot historical backfill
+(:func:`async_import_family_history`) plus an hourly point of the live cumulative
+value (:func:`async_record_family_live_statistics`) to keep it current.
+
+The cloud reports the *true lifetime cumulative*, so every imported ``sum`` is an
+absolute cumulative value; re-running is idempotent (buckets are keyed by start,
+and the historical backfill clears the series first).
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date
 import logging
 from typing import Any
 
+from homeassistant.components.recorder import DOMAIN as RECORDER_DOMAIN, get_instance
 from homeassistant.components.recorder.models import StatisticData, StatisticMetaData
-from homeassistant.components.recorder.statistics import async_add_external_statistics
+from homeassistant.components.recorder.statistics import async_import_statistics
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import UnitOfEnergy
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from .api_client import SunlitApiClient
@@ -30,7 +45,6 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 # ``mean_type`` (Home Assistant 2025.5+) replaced the deprecated ``has_mean``.
-# Stay compatible with the integration's documented minimum HA version.
 try:
     from homeassistant.components.recorder.models import StatisticMeanType
 
@@ -49,6 +63,28 @@ class DailyEarning:
     generation_kwh: float
     earnings: float
     currency: str
+
+
+@dataclass(frozen=True)
+class _Series:
+    """A statistics series owned by the integration for a family sensor."""
+
+    key: str  # sensor key, e.g. "lifetime_yield"
+    unit_class: str | None
+    unit: str | None  # None -> resolved to the account currency
+    value: Callable[[DailyEarning], float]
+
+
+def _series_specs(currency: str) -> list[_Series]:
+    return [
+        _Series(
+            "lifetime_yield",
+            "energy",
+            UnitOfEnergy.KILO_WATT_HOUR,
+            lambda item: item.generation_kwh,
+        ),
+        _Series("lifetime_earnings", None, currency, lambda item: item.earnings),
+    ]
 
 
 def _as_float(value: Any) -> float:
@@ -72,6 +108,33 @@ def _has_data(bucket: dict[str, Any]) -> bool:
     return (
         _as_float(bucket.get("totalPowerGeneration")) != 0.0
         or _as_float(bucket.get("totalEarnings")) != 0.0
+    )
+
+
+def resolve_statistic_id(
+    hass: HomeAssistant, family_name: str, family_id: str | int, key: str
+) -> str | None:
+    """Resolve the live entity_id for a family sensor (its statistic_id).
+
+    Users can rename entity_ids, so we look it up from the registry by the
+    integration's stable unique_id rather than assuming the slug.
+    """
+    unique_id = f"sunlit_{family_name.lower().replace(' ', '_')}_{family_id}_{key}"
+    return er.async_get(hass).async_get_entity_id(SENSOR_DOMAIN, DOMAIN, unique_id)
+
+
+def _metadata(
+    statistic_id: str, unit_class: str | None, unit: str | None
+) -> StatisticMetaData:
+    """Build entity-statistics metadata (source must be the recorder domain)."""
+    return StatisticMetaData(
+        **_MEAN_META,
+        has_sum=True,
+        name=None,  # entity statistics: HA uses the entity's own friendly name
+        source=RECORDER_DOMAIN,
+        statistic_id=statistic_id,
+        unit_class=unit_class,
+        unit_of_measurement=unit,
     )
 
 
@@ -134,70 +197,50 @@ async def async_collect_earning_history(
     return daily
 
 
-def build_external_statistics(
-    space_id: str | int,
-    family_name: str,
+def build_series_statistics(
+    statistic_id: str,
+    series: _Series,
     daily: list[DailyEarning],
-    currency: str,
-) -> list[tuple[StatisticMetaData, list[StatisticData]]]:
-    """Turn daily buckets into (metadata, cumulative statistics) pairs.
+) -> tuple[StatisticMetaData, list[StatisticData]]:
+    """Build (metadata, cumulative statistics) for one series.
 
-    Both series are cumulative sums (``has_sum``); the Energy Dashboard derives
-    each period's value from the difference of consecutive ``sum`` values.
+    Values are cumulative sums (``has_sum``); the Energy Dashboard derives each
+    period from the difference of consecutive ``sum`` values.
     """
-    energy_meta = StatisticMetaData(
-        **_MEAN_META,
-        has_sum=True,
-        name=f"{family_name} Lifetime Yield (imported history)",
-        source=DOMAIN,
-        statistic_id=f"{DOMAIN}:{space_id}_lifetime_yield",
-        unit_class="energy",
-        unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-    )
-    earnings_meta = StatisticMetaData(
-        **_MEAN_META,
-        has_sum=True,
-        name=f"{family_name} Lifetime Earnings (imported history)",
-        source=DOMAIN,
-        statistic_id=f"{DOMAIN}:{space_id}_lifetime_earnings",
-        unit_class=None,
-        unit_of_measurement=currency,
-    )
-
-    energy_stats: list[StatisticData] = []
-    earnings_stats: list[StatisticData] = []
-    running_energy = 0.0
-    running_earnings = 0.0
+    metadata = _metadata(statistic_id, series.unit_class, series.unit)
+    stats: list[StatisticData] = []
+    running = 0.0
     for item in sorted(daily, key=lambda entry: entry.date):
-        start = dt_util.start_of_local_day(item.date)
-        running_energy += item.generation_kwh
-        running_earnings += item.earnings
-        energy_stats.append(
-            StatisticData(start=start, state=item.generation_kwh, sum=running_energy)
+        value = series.value(item)
+        running += value
+        stats.append(
+            StatisticData(
+                start=dt_util.start_of_local_day(item.date),
+                state=value,
+                sum=running,
+            )
         )
-        earnings_stats.append(
-            StatisticData(start=start, state=item.earnings, sum=running_earnings)
-        )
-
-    return [(energy_meta, energy_stats), (earnings_meta, earnings_stats)]
+    return metadata, stats
 
 
 async def async_import_family_history(
     hass: HomeAssistant,
     api: SunlitApiClient,
-    space_id: str | int,
+    family_id: str | int,
     family_name: str,
 ) -> int:
-    """Backfill historical generation & earnings statistics for one space.
+    """Backfill historical statistics onto the family's lifetime entities.
 
-    Returns the number of days imported.
+    Clears each entity's existing (recorder-compiled) statistics first so the
+    imported absolute-cumulative series is internally consistent, then imports
+    the full history. Returns the number of days imported.
     """
     today = dt_util.now().date()
-    daily = await async_collect_earning_history(api, space_id, today)
+    daily = await async_collect_earning_history(api, family_id, today)
     if not daily:
         _LOGGER.warning(
             "No historical earning data returned for space %s (%s)",
-            space_id,
+            family_id,
             family_name,
         )
         return 0
@@ -206,16 +249,59 @@ async def async_import_family_history(
         (item.currency for item in reversed(daily) if item.currency),
         _DEFAULT_CURRENCY,
     )
-    for metadata, statistics in build_external_statistics(
-        space_id, family_name, daily, currency
-    ):
-        if statistics:
-            async_add_external_statistics(hass, metadata, statistics)
+    recorder = get_instance(hass)
+    imported = 0
+    for series in _series_specs(currency):
+        statistic_id = resolve_statistic_id(hass, family_name, family_id, series.key)
+        if not statistic_id:
+            _LOGGER.warning(
+                "Cannot backfill %s for space %s: entity not found",
+                series.key,
+                family_id,
+            )
+            continue
+        # Replace any recorder-compiled stats so the absolute-cumulative series
+        # we import is not interleaved with relative-sum buckets.
+        recorder.async_clear_statistics([statistic_id])
+        metadata, statistics = build_series_statistics(statistic_id, series, daily)
+        async_import_statistics(hass, metadata, statistics)
+        imported = max(imported, len(statistics))
 
     _LOGGER.info(
         "Imported %s day(s) of historical statistics for space %s (%s)",
-        len(daily),
-        space_id,
+        imported,
+        family_id,
         family_name,
     )
-    return len(daily)
+    return imported
+
+
+@callback
+def async_record_family_live_statistics(
+    hass: HomeAssistant, family_coordinator: Any
+) -> None:
+    """Append the current hour's cumulative point for the lifetime entities.
+
+    Called hourly. Because these sensors have no ``state_class``, the recorder
+    no longer compiles their statistics, so this keeps the integration-owned
+    series current using the already-polled live cumulative values.
+    """
+    data = family_coordinator.data or {}
+    family_id = family_coordinator.family_id
+    family_name = family_coordinator.family_name
+    currency = data.get("currency") or _DEFAULT_CURRENCY
+    hour = dt_util.utcnow().replace(minute=0, second=0, microsecond=0)
+
+    for series in _series_specs(currency):
+        value = data.get(series.key)
+        if not isinstance(value, (int, float)):
+            continue
+        statistic_id = resolve_statistic_id(hass, family_name, family_id, series.key)
+        if not statistic_id:
+            continue
+        metadata = _metadata(statistic_id, series.unit_class, series.unit)
+        async_import_statistics(
+            hass,
+            metadata,
+            [StatisticData(start=hour, state=float(value), sum=float(value))],
+        )

--- a/custom_components/sunlit/strings.json
+++ b/custom_components/sunlit/strings.json
@@ -58,5 +58,11 @@
         }
       }
     }
+  },
+  "services": {
+    "import_history": {
+      "name": "Import historical statistics",
+      "description": "Backfill historical generation and earnings from the Sunlit / SunEnergyXT cloud into Home Assistant's long-term statistics, so pre-install history shows up in the Energy Dashboard and Statistics cards. Safe to run more than once; existing daily buckets are overwritten rather than duplicated."
+    }
   }
 }

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -423,6 +423,60 @@ async def test_fetch_space_statistics_dynamic_energy_success(api_client, mock_se
 
 
 @pytest.mark.asyncio
+async def test_fetch_space_statistics_dynamic_earning_success(api_client, mock_session):
+    """Test fetching generation & earnings buckets (history backfill source)."""
+    setup_mock_response(
+        mock_session,
+        200,
+        {
+            "code": 0,
+            "message": {"DE": "Ok"},
+            "content": {
+                "totalPowerGeneration": 12.0,
+                "totalEarnings": {"earnings": 4.0, "currency": "EUR"},
+                "powerEarningsList": [
+                    {
+                        "key": 1,
+                        "totalPowerGeneration": 2.0,
+                        "totalEarnings": 0.6,
+                        "currency": "EUR",
+                    }
+                ],
+                "chargingEnergyList": [{"key": 1, "chargingEnergy": 0}],
+            },
+        },
+    )
+
+    data = await api_client.fetch_space_statistics_dynamic_earning(
+        34038, year=2024, month=1
+    )
+
+    assert data["totalPowerGeneration"] == 12.0
+    assert data["powerEarningsList"][0]["totalEarnings"] == 0.6
+
+    mock_session.request.assert_called_once()
+    call_args = mock_session.request.call_args
+    assert call_args[0][0] == "POST"
+    assert "/v1.1/space/statistics/dynamic/earning" in call_args[0][1]
+    assert call_args[1]["json"] == {"spaceId": 34038, "year": 2024, "month": 1}
+
+
+@pytest.mark.asyncio
+async def test_fetch_space_statistics_dynamic_earning_all_time(api_client, mock_session):
+    """Omitting year/month requests all-time per-year buckets."""
+    setup_mock_response(
+        mock_session,
+        200,
+        {"code": 0, "message": {"DE": "Ok"}, "content": {"powerEarningsList": []}},
+    )
+
+    await api_client.fetch_space_statistics_dynamic_earning(34038)
+
+    call_args = mock_session.request.call_args
+    assert call_args[1]["json"] == {"spaceId": 34038}
+
+
+@pytest.mark.asyncio
 async def test_fetch_notification_list_success(api_client, mock_session):
     """Test fetching the paginated notification feed."""
     setup_mock_response(

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -213,10 +213,13 @@ class TestStateClassForSensor:
             ), f"Failed for {sensor}"
 
     def test_total_sensors(self):
-        """Only monetary totals use TOTAL (MONETARY forbids TOTAL_INCREASING)."""
+        """Only daily_earnings uses TOTAL (MONETARY forbids TOTAL_INCREASING).
+
+        lifetime_earnings is integration-managed long-term statistics (no
+        state_class) — covered by TestLifetimeStatsSensors.
+        """
         total_sensors = [
             "daily_earnings",  # resets daily -> carries a last_reset (see entity)
-            "lifetime_earnings",
         ]
         for sensor in total_sensors:
             assert (
@@ -419,22 +422,24 @@ class TestLifetimeStatsSensors:
     """Test classification of lifetime yield & earnings sensors (issue #155)."""
 
     def test_lifetime_yield(self):
-        """lifetime_yield is a cumulative energy sensor in kWh."""
+        """lifetime_yield is energy in kWh with integration-managed statistics.
+
+        It has no state_class: the integration owns its long-term statistics
+        (historical backfill + ongoing hourly import) so the recorder must not
+        also auto-compile them. See statistics.py.
+        """
         assert get_device_class_for_sensor("lifetime_yield") == SensorDeviceClass.ENERGY
-        assert (
-            get_state_class_for_sensor("lifetime_yield")
-            == SensorStateClass.TOTAL_INCREASING
-        )
+        assert get_state_class_for_sensor("lifetime_yield") is None
         assert get_unit_for_sensor("lifetime_yield") == UnitOfEnergy.KILO_WATT_HOUR
         assert get_icon_for_sensor("lifetime_yield") == "mdi:solar-power-variant"
 
     def test_lifetime_earnings(self):
-        """lifetime_earnings is a cumulative monetary sensor."""
+        """lifetime_earnings is monetary with integration-managed statistics."""
         assert (
             get_device_class_for_sensor("lifetime_earnings")
             == SensorDeviceClass.MONETARY
         )
-        assert get_state_class_for_sensor("lifetime_earnings") == SensorStateClass.TOTAL
+        assert get_state_class_for_sensor("lifetime_earnings") is None
         assert get_unit_for_sensor("lifetime_earnings") == "EUR"
         assert get_icon_for_sensor("lifetime_earnings") == "mdi:cash"
 

--- a/tests/test_statistics_backfill.py
+++ b/tests/test_statistics_backfill.py
@@ -1,0 +1,173 @@
+"""Tests for historical long-term statistics backfill."""
+
+from datetime import UTC, date, datetime
+from unittest.mock import MagicMock, patch
+
+from homeassistant.util import dt as dt_util
+import pytest
+
+from custom_components.sunlit.statistics import (
+    DailyEarning,
+    async_collect_earning_history,
+    async_import_family_history,
+    build_external_statistics,
+)
+
+
+class FakeEarningApi:
+    """Minimal fake exposing fetch_space_statistics_dynamic_earning."""
+
+    def __init__(self, years, months, days):
+        self._years = years
+        self._months = months
+        self._days = days
+        self.calls: list[tuple[int | None, int | None]] = []
+
+    async def fetch_space_statistics_dynamic_earning(
+        self, space_id, year=None, month=None
+    ):
+        self.calls.append((year, month))
+        if year is None:
+            return self._years
+        if month is None:
+            return self._months.get(year, {"powerEarningsList": []})
+        return self._days.get((year, month), {"powerEarningsList": []})
+
+
+def _bucket(key, gen=0.0, earn=0.0, currency="EUR"):
+    return {
+        "key": key,
+        "totalPowerGeneration": gen,
+        "totalEarnings": earn,
+        "currency": currency,
+    }
+
+
+def _sample_api():
+    years = {
+        "powerEarningsList": [
+            _bucket(2023, gen=0.0, earn=0.0),  # no data -> pruned
+            _bucket(2024, gen=12.0, earn=4.0),
+            _bucket(2025, gen=99.0, earn=9.0),  # future year -> skipped
+        ]
+    }
+    months = {
+        2024: {
+            "powerEarningsList": [
+                _bucket(1, gen=5.0, earn=1.5),
+                _bucket(2, gen=0.0, earn=0.0),  # no data -> pruned
+                _bucket(3, gen=7.0, earn=2.5),
+                _bucket(4, gen=99.0, earn=9.0),  # future month -> skipped
+            ]
+        }
+    }
+    days = {
+        (2024, 1): {
+            "powerEarningsList": [
+                _bucket(1, gen=2.0, earn=0.6),
+                _bucket(2, gen=3.0, earn=0.9),
+            ]
+        },
+        (2024, 3): {
+            "powerEarningsList": [
+                _bucket(9, gen=1.0, earn=0.3),
+                _bucket(10, gen=1.5, earn=0.4),
+                _bucket(11, gen=99.0, earn=9.0),  # future day -> skipped
+            ]
+        },
+    }
+    return FakeEarningApi(years, months, days)
+
+
+async def test_collect_earning_history_walks_and_caps():
+    """Walk year->month->day, pruning empty buckets and future periods."""
+    api = _sample_api()
+    today = date(2024, 3, 10)
+
+    daily = await async_collect_earning_history(api, "34038", today)
+
+    assert [d.date for d in daily] == [
+        date(2024, 1, 1),
+        date(2024, 1, 2),
+        date(2024, 3, 9),
+        date(2024, 3, 10),
+    ]
+    assert [d.generation_kwh for d in daily] == [2.0, 3.0, 1.0, 1.5]
+    assert [d.earnings for d in daily] == [0.6, 0.9, 0.3, 0.4]
+    assert all(d.currency == "EUR" for d in daily)
+
+    # Empty month (2024-02) and future periods were never fetched.
+    assert (2024, 2) not in api.calls
+    assert (2024, 4) not in api.calls
+    assert (2025, None) not in api.calls
+
+
+async def test_collect_earning_history_empty():
+    """No history yields an empty list."""
+    api = FakeEarningApi({"powerEarningsList": []}, {}, {})
+    daily = await async_collect_earning_history(api, "34038", date(2024, 1, 1))
+    assert daily == []
+
+
+def test_build_external_statistics_cumulative_sums():
+    """Statistics are cumulative sums with hour-aligned starts."""
+    daily = [
+        DailyEarning(date(2024, 1, 1), 2.0, 0.6, "EUR"),
+        DailyEarning(date(2024, 1, 2), 3.0, 0.9, "EUR"),
+        DailyEarning(date(2024, 3, 9), 1.0, 0.3, "EUR"),
+        DailyEarning(date(2024, 3, 10), 1.5, 0.4, "EUR"),
+    ]
+
+    series = build_external_statistics("34038", "Garage", daily, "EUR")
+    assert len(series) == 2
+    (energy_meta, energy_stats), (earnings_meta, earnings_stats) = series
+
+    assert energy_meta["statistic_id"] == "sunlit:34038_lifetime_yield"
+    assert energy_meta["source"] == "sunlit"
+    assert energy_meta["has_sum"] is True
+    assert energy_meta["unit_of_measurement"] == "kWh"
+    assert earnings_meta["statistic_id"] == "sunlit:34038_lifetime_earnings"
+    assert earnings_meta["unit_of_measurement"] == "EUR"
+
+    assert [s["sum"] for s in energy_stats] == pytest.approx([2.0, 5.0, 6.0, 7.5])
+    assert [s["state"] for s in energy_stats] == pytest.approx([2.0, 3.0, 1.0, 1.5])
+    assert [s["sum"] for s in earnings_stats] == pytest.approx([0.6, 1.5, 1.8, 2.2])
+
+    # Starts are local midnight, ascending and hour-aligned.
+    starts = [s["start"] for s in energy_stats]
+    assert starts == [dt_util.start_of_local_day(d.date) for d in daily]
+    assert all(s.minute == 0 and s.second == 0 for s in starts)
+    assert starts == sorted(starts)
+
+
+async def test_import_family_history_pushes_two_series():
+    """The orchestrator imports both energy and earnings series."""
+    api = _sample_api()
+    now = datetime(2024, 3, 10, 12, tzinfo=UTC)
+    with (
+        patch("custom_components.sunlit.statistics.dt_util.now", return_value=now),
+        patch(
+            "custom_components.sunlit.statistics.async_add_external_statistics"
+        ) as mock_add,
+    ):
+        count = await async_import_family_history(MagicMock(), api, "34038", "Garage")
+
+    assert count == 4
+    assert mock_add.call_count == 2
+    statistic_ids = {call.args[1]["statistic_id"] for call in mock_add.call_args_list}
+    assert statistic_ids == {
+        "sunlit:34038_lifetime_yield",
+        "sunlit:34038_lifetime_earnings",
+    }
+
+
+async def test_import_family_history_no_data_skips():
+    """No history imports nothing and returns zero."""
+    api = FakeEarningApi({"powerEarningsList": []}, {}, {})
+    with patch(
+        "custom_components.sunlit.statistics.async_add_external_statistics"
+    ) as mock_add:
+        count = await async_import_family_history(MagicMock(), api, "34038", "Garage")
+
+    assert count == 0
+    mock_add.assert_not_called()

--- a/tests/test_statistics_backfill.py
+++ b/tests/test_statistics_backfill.py
@@ -1,4 +1,4 @@
-"""Tests for historical long-term statistics backfill."""
+"""Tests for historical + live long-term statistics (imported onto entities)."""
 
 from datetime import UTC, date, datetime
 from unittest.mock import MagicMock, patch
@@ -8,9 +8,11 @@ import pytest
 
 from custom_components.sunlit.statistics import (
     DailyEarning,
+    _series_specs,
     async_collect_earning_history,
     async_import_family_history,
-    build_external_statistics,
+    async_record_family_live_statistics,
+    build_series_statistics,
 )
 
 
@@ -32,6 +34,15 @@ class FakeEarningApi:
         if month is None:
             return self._months.get(year, {"powerEarningsList": []})
         return self._days.get((year, month), {"powerEarningsList": []})
+
+
+class FakeFamilyCoordinator:
+    """Stand-in for SunlitFamilyCoordinator used by the live recorder."""
+
+    def __init__(self, data, family_id="34038", family_name="Garage"):
+        self.data = data
+        self.family_id = family_id
+        self.family_name = family_name
 
 
 def _bucket(key, gen=0.0, earn=0.0, currency="EUR"):
@@ -79,6 +90,15 @@ def _sample_api():
     return FakeEarningApi(years, months, days)
 
 
+def _sample_daily():
+    return [
+        DailyEarning(date(2024, 1, 1), 2.0, 0.6, "EUR"),
+        DailyEarning(date(2024, 1, 2), 3.0, 0.9, "EUR"),
+        DailyEarning(date(2024, 3, 9), 1.0, 0.3, "EUR"),
+        DailyEarning(date(2024, 3, 10), 1.5, 0.4, "EUR"),
+    ]
+
+
 async def test_collect_earning_history_walks_and_caps():
     """Walk year->month->day, pruning empty buckets and future periods."""
     api = _sample_api()
@@ -109,65 +129,153 @@ async def test_collect_earning_history_empty():
     assert daily == []
 
 
-def test_build_external_statistics_cumulative_sums():
-    """Statistics are cumulative sums with hour-aligned starts."""
-    daily = [
-        DailyEarning(date(2024, 1, 1), 2.0, 0.6, "EUR"),
-        DailyEarning(date(2024, 1, 2), 3.0, 0.9, "EUR"),
-        DailyEarning(date(2024, 3, 9), 1.0, 0.3, "EUR"),
-        DailyEarning(date(2024, 3, 10), 1.5, 0.4, "EUR"),
-    ]
+def test_build_series_statistics_cumulative_sums():
+    """Series build cumulative sums onto an entity statistic_id (source=recorder)."""
+    daily = _sample_daily()
+    yield_series, earnings_series = _series_specs("EUR")
 
-    series = build_external_statistics("34038", "Garage", daily, "EUR")
-    assert len(series) == 2
-    (energy_meta, energy_stats), (earnings_meta, earnings_stats) = series
+    energy_meta, energy_stats = build_series_statistics(
+        "sensor.sunlit_garage_34038_lifetime_yield", yield_series, daily
+    )
+    earn_meta, earn_stats = build_series_statistics(
+        "sensor.sunlit_garage_34038_lifetime_earnings", earnings_series, daily
+    )
 
-    assert energy_meta["statistic_id"] == "sunlit:34038_lifetime_yield"
-    assert energy_meta["source"] == "sunlit"
+    # Entity statistics: dotted statistic_id, source must be "recorder", no name.
+    assert energy_meta["statistic_id"] == "sensor.sunlit_garage_34038_lifetime_yield"
+    assert energy_meta["source"] == "recorder"
+    assert energy_meta["name"] is None
     assert energy_meta["has_sum"] is True
     assert energy_meta["unit_of_measurement"] == "kWh"
-    assert earnings_meta["statistic_id"] == "sunlit:34038_lifetime_earnings"
-    assert earnings_meta["unit_of_measurement"] == "EUR"
+    assert energy_meta["unit_class"] == "energy"
+    assert earn_meta["unit_of_measurement"] == "EUR"
+    assert earn_meta["unit_class"] is None
 
     assert [s["sum"] for s in energy_stats] == pytest.approx([2.0, 5.0, 6.0, 7.5])
     assert [s["state"] for s in energy_stats] == pytest.approx([2.0, 3.0, 1.0, 1.5])
-    assert [s["sum"] for s in earnings_stats] == pytest.approx([0.6, 1.5, 1.8, 2.2])
+    assert [s["sum"] for s in earn_stats] == pytest.approx([0.6, 1.5, 1.8, 2.2])
 
-    # Starts are local midnight, ascending and hour-aligned.
     starts = [s["start"] for s in energy_stats]
     assert starts == [dt_util.start_of_local_day(d.date) for d in daily]
     assert all(s.minute == 0 and s.second == 0 for s in starts)
     assert starts == sorted(starts)
 
 
-async def test_import_family_history_pushes_two_series():
-    """The orchestrator imports both energy and earnings series."""
+async def test_import_family_history_imports_onto_entities():
+    """History is cleared and re-imported onto the resolved entity ids."""
     api = _sample_api()
     now = datetime(2024, 3, 10, 12, tzinfo=UTC)
+    recorder = MagicMock()
     with (
         patch("custom_components.sunlit.statistics.dt_util.now", return_value=now),
         patch(
-            "custom_components.sunlit.statistics.async_add_external_statistics"
-        ) as mock_add,
+            "custom_components.sunlit.statistics.resolve_statistic_id",
+            side_effect=lambda hass, name, fid, key: f"sensor.sunlit_{fid}_{key}",
+        ),
+        patch(
+            "custom_components.sunlit.statistics.get_instance",
+            return_value=recorder,
+        ),
+        patch(
+            "custom_components.sunlit.statistics.async_import_statistics"
+        ) as mock_import,
     ):
         count = await async_import_family_history(MagicMock(), api, "34038", "Garage")
 
     assert count == 4
-    assert mock_add.call_count == 2
-    statistic_ids = {call.args[1]["statistic_id"] for call in mock_add.call_args_list}
-    assert statistic_ids == {
-        "sunlit:34038_lifetime_yield",
-        "sunlit:34038_lifetime_earnings",
+    assert mock_import.call_count == 2
+    statistic_ids = {
+        call.args[1]["statistic_id"] for call in mock_import.call_args_list
     }
+    assert statistic_ids == {
+        "sensor.sunlit_34038_lifetime_yield",
+        "sensor.sunlit_34038_lifetime_earnings",
+    }
+    # Existing recorder statistics are cleared before re-import.
+    cleared = {
+        call.args[0][0] for call in recorder.async_clear_statistics.call_args_list
+    }
+    assert cleared == statistic_ids
 
 
 async def test_import_family_history_no_data_skips():
     """No history imports nothing and returns zero."""
     api = FakeEarningApi({"powerEarningsList": []}, {}, {})
-    with patch(
-        "custom_components.sunlit.statistics.async_add_external_statistics"
-    ) as mock_add:
+    with (
+        patch("custom_components.sunlit.statistics.get_instance"),
+        patch(
+            "custom_components.sunlit.statistics.async_import_statistics"
+        ) as mock_import,
+    ):
         count = await async_import_family_history(MagicMock(), api, "34038", "Garage")
 
     assert count == 0
-    mock_add.assert_not_called()
+    mock_import.assert_not_called()
+
+
+async def test_import_family_history_skips_missing_entity():
+    """When an entity is not registered yet, that series is skipped."""
+    api = _sample_api()
+    now = datetime(2024, 3, 10, 12, tzinfo=UTC)
+    with (
+        patch("custom_components.sunlit.statistics.dt_util.now", return_value=now),
+        patch(
+            "custom_components.sunlit.statistics.resolve_statistic_id",
+            return_value=None,
+        ),
+        patch("custom_components.sunlit.statistics.get_instance"),
+        patch(
+            "custom_components.sunlit.statistics.async_import_statistics"
+        ) as mock_import,
+    ):
+        count = await async_import_family_history(MagicMock(), api, "34038", "Garage")
+
+    assert count == 0
+    mock_import.assert_not_called()
+
+
+def test_record_family_live_statistics_appends_current_hour():
+    """The hourly recorder appends one cumulative point per series."""
+    coordinator = FakeFamilyCoordinator(
+        {"lifetime_yield": 123.4, "lifetime_earnings": 45.6, "currency": "EUR"}
+    )
+    with (
+        patch(
+            "custom_components.sunlit.statistics.resolve_statistic_id",
+            side_effect=lambda hass, name, fid, key: f"sensor.sunlit_{fid}_{key}",
+        ),
+        patch(
+            "custom_components.sunlit.statistics.async_import_statistics"
+        ) as mock_import,
+    ):
+        async_record_family_live_statistics(MagicMock(), coordinator)
+
+    assert mock_import.call_count == 2
+    by_id = {
+        call.args[1]["statistic_id"]: call.args[2]
+        for call in mock_import.call_args_list
+    }
+    yield_stats = by_id["sensor.sunlit_34038_lifetime_yield"]
+    assert len(yield_stats) == 1
+    assert yield_stats[0]["sum"] == 123.4
+    assert yield_stats[0]["state"] == 123.4
+    assert yield_stats[0]["start"].minute == 0
+    assert yield_stats[0]["start"].second == 0
+    assert by_id["sensor.sunlit_34038_lifetime_earnings"][0]["sum"] == 45.6
+
+
+def test_record_family_live_statistics_skips_missing_values():
+    """Missing lifetime values are skipped without importing."""
+    coordinator = FakeFamilyCoordinator({"currency": "EUR"})
+    with (
+        patch(
+            "custom_components.sunlit.statistics.resolve_statistic_id",
+            side_effect=lambda hass, name, fid, key: f"sensor.sunlit_{fid}_{key}",
+        ),
+        patch(
+            "custom_components.sunlit.statistics.async_import_statistics"
+        ) as mock_import,
+    ):
+        async_record_family_live_statistics(MagicMock(), coordinator)
+
+    mock_import.assert_not_called()


### PR DESCRIPTION
Closes #180.

## What

Home Assistant only keeps statistics from the moment a sensor starts recording. The cloud already holds years of generation & earnings history, so this adds an **opt-in** import that backfills it into HA's long-term statistics — pre-install history then appears in the **Energy Dashboard** and **Statistics cards** without creating any entities.

## How

- **`api_client.fetch_space_statistics_dynamic_earning(space_id, year, month)`** — wraps the previously-unused `POST /v1.1/space/statistics/dynamic/earning` endpoint.
- **`statistics.py`** — walks the endpoint at year → month → day granularity, prunes empty years/months and future buckets (so the current month's not-yet-recorded days aren't imported as zeros), then emits two **external** statistics as cumulative sums:
  - `sunlit:<space>_lifetime_yield` (kWh, `has_sum`)
  - `sunlit:<space>_lifetime_earnings` (account currency, `has_sum`)
- **Service `sunlit.import_history`** — user-invoked, runs for every configured space. Idempotent: external statistics are keyed by `start`, so re-running overwrites the same daily buckets rather than double-counting.
- **manifest** gains `after_dependencies: [recorder]`; `services.yaml` + `strings.json` describe the service.

## Design notes

- **External** statistics (not entity statistics) — matches the issue's "no new entities" and avoids conflicting with the recorder's automatic compilation of the live `lifetime_yield` sensor.
- Daily resolution (one hour-aligned point per local midnight) is sufficient for historical Energy-Dashboard views.
- Statistics metadata uses `mean_type` (HA 2025.5+) with a `has_mean` fallback for the documented minimum HA version.
- Opt-in via service rather than auto-on-setup, since the issue frames this as advanced/optional and it avoids extra startup API load. Auto-run-once could be a follow-up.

## Tests

- `tests/test_statistics_backfill.py`: granularity walk + pruning/future-capping, cumulative-sum builder (sums, hour-aligned starts, units), and the orchestrator (two series imported; no-data short-circuit).
- `tests/test_api_client.py`: the new earning endpoint wrapper (with and without year/month).

213 tests pass; coverage 74.5% total, `statistics.py` 91%. `ruff`/`ruff-format`/`isort` clean on `custom_components/`.

## Try it

Developer Tools → Actions → **Sunlit: Import historical statistics**, then check Settings → Dashboards → Energy (or a Statistics card) for the new `sunlit:…` series.