### PR TITLE
feat(sensors): add battery stored-energy sensors (ENERGY_STORAGE) (#190)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The integration will create devices, sensors, and controls automatically based o
 | `offline_devices`           | Number of offline devices         | count    | 30s    |
 | `total_ac_power`            | Combined AC power from all meters | W        | 30s    |
 | `average_battery_level`     | Average SOC across all batteries  | %        | 30s    |
+| `total_stored_energy`       | Energy stored in the battery pack (SOC × capacity) | kWh | 30s |
 | `total_input_power`         | Total battery charging power      | W        | 30s    |
 | `total_output_power`        | Total battery discharging power   | W        | 30s    |
 | `inverter_current_power`    | Inverter output power             | W        | 30s    |
@@ -183,6 +184,7 @@ The integration will create devices, sensors, and controls automatically based o
 | --------------------- | --------------------------- | ------- |
 | `battery_level`       | Current state of charge     | %       |
 | `batterySoc`          | System battery SOC          | %       |
+| `stored_energy`       | Energy stored in the pack (SOC × capacity, `ENERGY_STORAGE`) | kWh |
 | `input_power_total`   | Current charging power      | W       |
 | `output_power_total`  | Current discharging power   | W       |
 | `chargeRemaining`     | Time until fully charged    | minutes |
@@ -210,6 +212,7 @@ For modular battery systems with B215 extension modules, each additional battery
 | `Mppt1InPower` | Module MPPT power      | W    |
 | `Mppt1Energy`  | Module MPPT total energy | kWh |
 | `capacity`     | Nominal capacity (2.15 kWh) | kWh |
+| `StoredEnergy` | Energy stored in the module (SOC × 2.15 kWh, `ENERGY_STORAGE`) | kWh |
 
 ### Binary Sensors
 

--- a/custom_components/sunlit/const.py
+++ b/custom_components/sunlit/const.py
@@ -12,6 +12,9 @@ VERSION = "1.8.0"  # x-release-please-version
 DEFAULT_NAME = "Sunlit REST Sensor"
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
 
+# Nominal capacity of one battery unit (BK215 head unit and each B215 module)
+BATTERY_MODULE_CAPACITY_KWH = 2.15
+
 # API Configuration
 # Current backend host used by the SunEnergyXT app (v1.8.1). The legacy
 # api.sunlitsolar.de host still resolves but the app has migrated here; both
@@ -112,6 +115,7 @@ BATTERY_SENSORS = {
     "input_power_total": "Total Input Power",
     "output_power_total": "Total Output Power",
     "battery_capacity": "Nominal Capacity",  # Static 2.15 kWh per unit
+    "stored_energy": "Stored Energy",  # SOC x total pack capacity (ENERGY_STORAGE)
     # Main unit MPPT sensors (head unit's solar inputs)
     "batteryMppt1InVol": "MPPT1 Voltage",
     "batteryMppt1InCur": "MPPT1 Current",
@@ -136,6 +140,7 @@ BATTERY_MODULE_SENSORS = {
     "Mppt1InPower": "MPPT Power",
     "Mppt1Energy": "MPPT Total Energy",
     "capacity": "Nominal Capacity",  # Static 2.15 kWh per module
+    "StoredEnergy": "Stored Energy",  # module SOC x 2.15 kWh (ENERGY_STORAGE)
 }
 
 # Family aggregate sensors
@@ -145,6 +150,7 @@ FAMILY_SENSORS = {
     "offline_devices": "Offline Devices",
     "total_ac_power": "Total AC Power",
     "average_battery_level": "Average Battery Level",
+    "total_stored_energy": "Total Stored Energy",  # avg SOC x pack capacity
     "total_input_power": "Total Input Power",
     "total_output_power": "Total Output Power",
     # has_fault moved to binary_sensor
@@ -230,6 +236,7 @@ SENSOR_GROUPS = {
     "battery_soc": SENSOR_GROUP_OVERVIEW,
     "batterySoc": SENSOR_GROUP_OVERVIEW,
     "average_battery_level": SENSOR_GROUP_OVERVIEW,
+    "total_stored_energy": SENSOR_GROUP_OVERVIEW,
     "total_ac_power": SENSOR_GROUP_OVERVIEW,
     "inverter_current_power": SENSOR_GROUP_OVERVIEW,
     "online_devices": SENSOR_GROUP_OVERVIEW,

--- a/custom_components/sunlit/coordinators/device.py
+++ b/custom_components/sunlit/coordinators/device.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from ..api_client import SunlitApiClient
-from ..const import DEFAULT_SCAN_INTERVAL
+from ..const import BATTERY_MODULE_CAPACITY_KWH, DEFAULT_SCAN_INTERVAL
 from ..event_manager import SunlitEventManager
 
 _LOGGER = logging.getLogger(__name__)
@@ -305,6 +305,20 @@ class SunlitDeviceCoordinator(DataUpdateCoordinator):
                 for i in range(1, module_count + 1):
                     soc_key = f"battery{i}Soc"
                     data[soc_key] = stats.get(soc_key)
+
+                # Stored energy (ENERGY_STORAGE) = SOC x nominal capacity. The
+                # system SOC covers the whole pack: the BK215 head unit plus the
+                # `module_count` B215 extension modules, each rated 2.15 kWh.
+                system_soc = data.get("batterySoc")
+                if system_soc is not None:
+                    pack_capacity = (1 + module_count) * BATTERY_MODULE_CAPACITY_KWH
+                    data["stored_energy"] = round(system_soc / 100 * pack_capacity, 3)
+                for i in range(1, module_count + 1):
+                    module_soc = data.get(f"battery{i}Soc")
+                    if module_soc is not None:
+                        data[f"battery{i}StoredEnergy"] = round(
+                            module_soc / 100 * BATTERY_MODULE_CAPACITY_KWH, 3
+                        )
 
                 # MPPT data
                 mppt_fields = [

--- a/custom_components/sunlit/coordinators/family.py
+++ b/custom_components/sunlit/coordinators/family.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from ..api_client import SunlitApiClient
-from ..const import DEFAULT_SCAN_INTERVAL
+from ..const import BATTERY_MODULE_CAPACITY_KWH, DEFAULT_SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -153,6 +153,15 @@ class SunlitFamilyCoordinator(DataUpdateCoordinator):
             if battery_data.get("deviceStatus") != "NotExist":
                 family_data["average_battery_level"] = battery_data.get("batteryLevel")
                 family_data["battery_count"] = battery_data.get("batteryCount")
+                # Total stored energy (ENERGY_STORAGE) = average SOC x pack
+                # capacity, where batteryCount is the number of 2.15 kWh units
+                # (BK215 head unit + B215 modules).
+                level = battery_data.get("batteryLevel")
+                count = battery_data.get("batteryCount")
+                if level is not None and count:
+                    family_data["total_stored_energy"] = round(
+                        level / 100 * count * BATTERY_MODULE_CAPACITY_KWH, 3
+                    )
                 family_data["battery_bypass"] = battery_data.get("bypass", False)
                 family_data["battery_charging_remaining"] = battery_data.get(
                     "chargingRemaining"

--- a/custom_components/sunlit/entities/helpers.py
+++ b/custom_components/sunlit/entities/helpers.py
@@ -24,6 +24,10 @@ def get_device_class_for_sensor(key: str) -> SensorDeviceClass | None:
         or key == "battery_full"
     ):
         return None
+    # Stored energy: current energy in the battery (kWh). Must precede the
+    # generic "energy"/"battery" checks so it is not mis-classified as ENERGY.
+    elif "storedenergy" in key.lower().replace("_", ""):
+        return SensorDeviceClass.ENERGY_STORAGE
     # Battery capacity
     elif (
         "capacity" in key.lower()
@@ -67,6 +71,9 @@ def get_device_class_for_sensor(key: str) -> SensorDeviceClass | None:
 
 def get_state_class_for_sensor(key: str) -> SensorStateClass | None:
     """Get the appropriate state class for a sensor."""
+    # Stored energy fluctuates (rises and falls) -> MEASUREMENT, never TOTAL*.
+    if "storedenergy" in key.lower().replace("_", ""):
+        return SensorStateClass.MEASUREMENT
     # Static configuration values don't need state class
     if key in ["rated_power", "max_output_power", "currency", "battery_count"]:
         return None
@@ -123,6 +130,9 @@ def get_state_class_for_sensor(key: str) -> SensorStateClass | None:
 
 def get_unit_for_sensor(key: str) -> str | None:
     """Get the appropriate unit for a sensor."""
+    # Stored energy (kWh)
+    if "storedenergy" in key.lower().replace("_", ""):
+        return UnitOfEnergy.KILO_WATT_HOUR
     # Battery capacity
     if (
         "capacity" in key.lower()
@@ -211,6 +221,9 @@ def get_icon_for_sensor(key: str, device_type: str = None) -> str | None:
     # Grid export tracking
     elif key == "total_grid_export_energy" or key == "daily_grid_export_energy":
         return "mdi:transmission-tower-export"
+    # Stored energy (before generic battery icons)
+    elif "storedenergy" in key.lower().replace("_", ""):
+        return "mdi:home-battery"
     # Battery related
     elif "battery_full" in key:
         return "mdi:battery-check"

--- a/tests/test_battery_stored_energy.py
+++ b/tests/test_battery_stored_energy.py
@@ -1,0 +1,87 @@
+"""Tests for battery stored-energy derivation (issue #190)."""
+
+from unittest.mock import AsyncMock
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.sunlit.const import BATTERY_MODULE_CAPACITY_KWH
+from custom_components.sunlit.coordinators.device import SunlitDeviceCoordinator
+
+CAP = BATTERY_MODULE_CAPACITY_KWH
+
+
+def _battery_device_list():
+    return [
+        {
+            "deviceId": "battery_001",
+            "deviceType": "ENERGY_STORAGE_BATTERY",
+            "status": "Online",
+            "batteryLevel": 80,
+            "deviceCount": 3,
+        }
+    ]
+
+
+async def _run(hass, stats):
+    api_client = AsyncMock()
+    api_client.fetch_device_list.return_value = _battery_device_list()
+    api_client.fetch_device_statistics.return_value = stats
+    api_client.fetch_device_details.return_value = {}
+    coordinator = SunlitDeviceCoordinator(hass, api_client, "34038", "Test Family")
+    data = await coordinator._async_update_data()
+    return data["devices"]["battery_001"]
+
+
+async def test_stored_energy_single_module(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    """One module: pack = head + 1 module = 2 x 2.15 kWh."""
+    battery = await _run(
+        hass,
+        {
+            "batterySoc": 50,
+            "battery1DeviceModel": "B_215",
+            "battery1Soc": 50,
+        },
+    )
+
+    assert battery["stored_energy"] == round(50 / 100 * (1 + 1) * CAP, 3)
+    assert battery["battery1StoredEnergy"] == round(50 / 100 * CAP, 3)
+    # No phantom second module.
+    assert "battery2StoredEnergy" not in battery
+
+
+async def test_stored_energy_multi_module(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    """Two modules: pack = head + 2 modules = 3 x 2.15 kWh; per-module independent."""
+    battery = await _run(
+        hass,
+        {
+            "batterySoc": 80,
+            "battery1DeviceModel": "B_215",
+            "battery1Soc": 70,
+            "battery2DeviceModel": "B_215",
+            "battery2Soc": 90,
+        },
+    )
+
+    assert battery["stored_energy"] == round(80 / 100 * (1 + 2) * CAP, 3)
+    assert battery["battery1StoredEnergy"] == round(70 / 100 * CAP, 3)
+    assert battery["battery2StoredEnergy"] == round(90 / 100 * CAP, 3)
+
+
+async def test_stored_energy_absent_without_soc(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    """No system SOC -> no stored_energy key (avoid a misleading 0)."""
+    battery = await _run(
+        hass,
+        {
+            "battery1DeviceModel": "B_215",
+            # batterySoc and battery1Soc absent
+        },
+    )
+
+    assert "stored_energy" not in battery
+    assert "battery1StoredEnergy" not in battery

--- a/tests/test_family_coordinator.py
+++ b/tests/test_family_coordinator.py
@@ -103,6 +103,9 @@ async def test_family_coordinator_update_success(
     assert family_data["total_input_power"] == 500
     assert family_data["total_output_power"] == 0
 
+    # Total stored energy (issue #190): avg SOC x batteryCount x 2.15 kWh
+    assert family_data["total_stored_energy"] == round(85 / 100 * 1 * 2.15, 3)
+
     # Check SOC limits
     assert family_data["hw_soc_min"] == 10
     assert family_data["hw_soc_max"] == 95

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -357,6 +357,32 @@ class TestLifetimeStatsSensors:
         assert get_icon_for_sensor("lifetime_earnings") == "mdi:cash"
 
 
+class TestStoredEnergySensors:
+    """Test classification of battery stored-energy sensors (issue #190)."""
+
+    @pytest.mark.parametrize(
+        "key",
+        ["stored_energy", "total_stored_energy", "battery1StoredEnergy"],
+    )
+    def test_stored_energy_classification(self, key):
+        """Stored energy is ENERGY_STORAGE / MEASUREMENT / kWh."""
+        assert (
+            get_device_class_for_sensor(key) == SensorDeviceClass.ENERGY_STORAGE
+        ), f"Failed device_class for {key}"
+        assert (
+            get_state_class_for_sensor(key) == SensorStateClass.MEASUREMENT
+        ), f"Failed state_class for {key}"
+        assert (
+            get_unit_for_sensor(key) == UnitOfEnergy.KILO_WATT_HOUR
+        ), f"Failed unit for {key}"
+
+    def test_stored_energy_not_total_increasing(self):
+        """Regression: stored energy must not be classified as a meter."""
+        assert get_state_class_for_sensor("stored_energy") != (
+            SensorStateClass.TOTAL_INCREASING
+        )
+
+
 class TestElectricityPriceSensors:
     """Test classification of dynamic tariff price sensors (issue #154)."""
 

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -604,9 +604,22 @@ async def test_battery_device_sensor_creation(
     (assert_sensors(sensors)
      .for_device("battery_001")
      .excluding_modules()
-     .where_key_matches(lambda k: "energy" in k.lower() or k == "battery_capacity")
+     .where_key_matches(
+         lambda k: ("energy" in k.lower() and "stored" not in k.lower())
+         or k == "battery_capacity"
+     )
      .matches_pattern(
          device_class=SensorDeviceClass.ENERGY,
+         unit=UnitOfEnergy.KILO_WATT_HOUR
+     ))
+
+    # Stored energy is ENERGY_STORAGE (the battery level), not ENERGY (issue #190)
+    (assert_sensors(sensors)
+     .for_device("battery_001")
+     .excluding_modules()
+     .where_key("stored_energy")
+     .matches_pattern(
+         device_class=SensorDeviceClass.ENERGY_STORAGE,
          unit=UnitOfEnergy.KILO_WATT_HOUR
      ))
 
@@ -771,6 +784,16 @@ async def test_battery_module_sensor_creation(
                 assert (
                     sensor.entity_description.native_unit_of_measurement
                     == UnitOfPower.WATT
+                )
+            elif "StoredEnergy" in key:
+                # Battery level (issue #190) — ENERGY_STORAGE, not ENERGY.
+                assert (
+                    sensor.entity_description.device_class
+                    == SensorDeviceClass.ENERGY_STORAGE
+                )
+                assert (
+                    sensor.entity_description.native_unit_of_measurement
+                    == UnitOfEnergy.KILO_WATT_HOUR
                 )
             elif "Energy" in key or "capacity" in key:
                 assert (
@@ -1207,6 +1230,16 @@ async def test_battery_module_sensor_creation(
                 assert (
                     sensor.entity_description.native_unit_of_measurement
                     == UnitOfPower.WATT
+                )
+            elif "StoredEnergy" in key:
+                # Battery level (issue #190) — ENERGY_STORAGE, not ENERGY.
+                assert (
+                    sensor.entity_description.device_class
+                    == SensorDeviceClass.ENERGY_STORAGE
+                )
+                assert (
+                    sensor.entity_description.native_unit_of_measurement
+                    == UnitOfEnergy.KILO_WATT_HOUR
                 )
             elif "Energy" in key or "capacity" in key:
                 assert (


### PR DESCRIPTION
Closes #190.

## What
Adds the current **energy stored** in the battery (kWh) as `SensorDeviceClass.ENERGY_STORAGE` sensors — the battery *level*, distinct from the Energy Dashboard's charge/discharge flow sensors.

- **Per battery device** — `stored_energy` = systemSOC × (1 + module_count) × 2.15 kWh
- **Per virtual module** — `battery{N}StoredEnergy` = moduleSOC × 2.15 kWh
- **Family rollup** — `total_stored_energy` = avgSOC × batteryCount × 2.15 kWh

All `device_class=ENERGY_STORAGE`, `state_class=MEASUREMENT` (rises **and** falls — never `total_increasing`), unit kWh.

## Derivation & data source
The cloud reports **SOC only** (no measured remaining-capacity field, verified against the fixtures), so this is the `SOC × nominal capacity` derivation the issue specifies. A new `BATTERY_MODULE_CAPACITY_KWH = 2.15` constant centralizes the per-unit capacity.

`batteryCount` counts every 2.15 kWh unit in the pack (the BK215 head unit **and** each B215 module) — confirmed from the fixtures (`batteryCount: 3` = 1 head + 2 modules), so the family rollup and the per-device value agree for a single-battery family.

Computed in the coordinators (where SOC + counts live), so the sensors read them via the normal data path — no `native_value` special-casing.

## Open question deferred (per the issue)
Reports **nominal** stored energy. A `usable_stored_energy` variant (subtracting the DoD / min-SOC limits we already expose) is a sensible follow-up.

## Tests
- `test_battery_stored_energy.py`: single- and multi-module device derivation, and the "no SOC → no key" guard.
- `test_family_coordinator.py`: family `total_stored_energy` aggregate.
- `test_sensor_helpers.py`: classification (ENERGY_STORAGE / MEASUREMENT / kWh; regression that it is **not** `total_increasing`).
- `test_sensor_platform.py`: updated the battery device/module sensor-creation assertions.

213 tests pass; coverage 74.6%; ruff/isort clean.