### PR TITLE
refactor(sensors): align device/state classes with HA sensor spec

### DIFF
--- a/custom_components/sunlit/entities/helpers.py
+++ b/custom_components/sunlit/entities/helpers.py
@@ -1,8 +1,15 @@
 """Helper functions for Sunlit sensors."""
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+import re
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.const import (
     PERCENTAGE,
+    EntityCategory,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
@@ -10,12 +17,43 @@ from homeassistant.const import (
     UnitOfTime,
 )
 
+# Text sensors with a known, bounded value set -> ENUM device class + options.
+# Only fields whose values are documented enums in the API are listed; strategy
+# and battery-status fields are intentionally excluded (their value sets are not
+# reliably bounded, so ENUM would emit "state not in options" warnings).
+ENUM_SENSOR_OPTIONS: dict[str, list[str]] = {
+    "electricity_price_tag": [
+        "VERY_CHEAP",
+        "CHEAP",
+        "NORMAL",
+        "EXPENSIVE",
+        "VERY_EXPENSIVE",
+    ],
+    "battery_device_status": ["Online", "Offline", "NotExist"],
+    "inverter_device_status": ["Online", "Offline", "NotExist"],
+    "meter_device_status": ["Online", "Offline", "NotExist"],
+}
+
+# Battery SOC that is actually metered and fluctuates -> SensorDeviceClass.BATTERY.
+# SOC *limits* (hw/bms/strategy/current min/max) are configuration thresholds,
+# not metered battery levels, so they are deliberately excluded.
+_METERED_SOC_KEYS = {"battery_level", "batterySoc", "average_battery_level"}
+_MODULE_SOC_RE = re.compile(r"^battery\d+Soc$")
+
+
+def _is_metered_battery_soc(key: str) -> bool:
+    """Return True for fluctuating, metered battery SOC sensors only."""
+    return key in _METERED_SOC_KEYS or _MODULE_SOC_RE.match(key) is not None
+
 
 def get_device_class_for_sensor(key: str) -> SensorDeviceClass | None:
     """Get the appropriate device class for a sensor."""
     # Check specific keys first before general pattern matching
     if key == "last_strategy_change":
         return SensorDeviceClass.TIMESTAMP
+    # Bounded text states -> ENUM (before the status guard, which would null them)
+    elif key in ENUM_SENSOR_OPTIONS:
+        return SensorDeviceClass.ENUM
     # Check for status and strategy fields (they're text, not numeric)
     elif (
         "status" in key.lower()
@@ -28,10 +66,10 @@ def get_device_class_for_sensor(key: str) -> SensorDeviceClass | None:
     # generic "energy"/"battery" checks so it is not mis-classified as ENERGY.
     elif "storedenergy" in key.lower().replace("_", ""):
         return SensorDeviceClass.ENERGY_STORAGE
-    # Battery capacity
+    # Cumulative/flow energy. Nominal capacity is intentionally NOT here: it is a
+    # static spec value, not metered energy (see get_entity_category -> diagnostic).
     elif (
-        "capacity" in key.lower()
-        or "mpptenergy" in key.lower().replace("_", "").replace(" ", "")
+        "mpptenergy" in key.lower().replace("_", "").replace(" ", "")
         or key == "total_solar_energy"
         or key in ["total_grid_export_energy", "daily_grid_export_energy"]
         or key in ["daily_yield", "lifetime_yield"]
@@ -62,7 +100,8 @@ def get_device_class_for_sensor(key: str) -> SensorDeviceClass | None:
         return SensorDeviceClass.CURRENT
     elif "energy" in key.lower():
         return SensorDeviceClass.ENERGY
-    elif "soc" in key.lower() or "battery" in key.lower() or "level" in key.lower():
+    # BATTERY only for metered, fluctuating SOC — not for SOC limit thresholds.
+    elif _is_metered_battery_soc(key):
         return SensorDeviceClass.BATTERY
     elif key == "has_fault":
         return None  # Binary-like sensor but as regular sensor
@@ -74,11 +113,8 @@ def get_state_class_for_sensor(key: str) -> SensorStateClass | None:
     # Stored energy fluctuates (rises and falls) -> MEASUREMENT, never TOTAL*.
     if "storedenergy" in key.lower().replace("_", ""):
         return SensorStateClass.MEASUREMENT
-    # Static configuration values don't need state class
-    if key in ["rated_power", "max_output_power", "currency", "battery_count"]:
-        return None
     # Lifetime cumulative energy sensors (never reset)
-    elif (
+    if (
         key == "total_yield"
         or key == "lifetime_yield"
         or "mpptenergy" in key.lower().replace("_", "").replace(" ", "")
@@ -89,7 +125,7 @@ def get_state_class_for_sensor(key: str) -> SensorStateClass | None:
     # TOTAL state class: daily counters that reset at midnight, plus
     # lifetime_earnings (cumulative monetary value, TOTAL per HA convention).
     # total_power_generation is actually today's daily generation.
-    elif key == "lifetime_earnings" or (
+    if key == "lifetime_earnings" or (
         key == "total_power_generation"
         or key == "daily_grid_export_energy"
         or key == "daily_yield"
@@ -97,26 +133,31 @@ def get_state_class_for_sensor(key: str) -> SensorStateClass | None:
     ):
         return SensorStateClass.TOTAL
     # Energy sensors need special handling
-    elif "energy" in key.lower():
+    if "energy" in key.lower():
         if "total" in key.lower():
-            # Total energy counters that never reset
             return SensorStateClass.TOTAL_INCREASING
         elif "daily" in key.lower():
-            # Daily energy counters that reset each day
             return SensorStateClass.TOTAL
         else:
-            # Other energy sensors
             return SensorStateClass.TOTAL_INCREASING
-    elif "power" in key.lower() or key in [
+    # Measurement-type device classes opt into long-term statistics. This covers
+    # power (incl. rated_power / max_output_power), voltage, current, metered
+    # battery SOC, time-remaining (duration) and stored energy.
+    if get_device_class_for_sensor(key) in (
+        SensorDeviceClass.POWER,
+        SensorDeviceClass.VOLTAGE,
+        SensorDeviceClass.CURRENT,
+        SensorDeviceClass.BATTERY,
+        SensorDeviceClass.DURATION,
+        SensorDeviceClass.ENERGY_STORAGE,
+    ):
+        return SensorStateClass.MEASUREMENT
+    # Numeric measurements that carry no device class (counts, prices, rates).
+    if key in [
         "device_count",
         "online_devices",
         "offline_devices",
         "strategy_changes_today",
-        "home_power",
-        "battery_charging_remaining",
-        "battery_discharging_remaining",
-        "inverter_current_power",
-        "total_solar_power",
         "electricity_price",
         "electricity_price_avg",
         "electricity_price_high",
@@ -317,3 +358,59 @@ def get_icon_for_sensor(key: str, device_type: str = None) -> str | None:
     elif key == "currency":
         return "mdi:currency-eur"
     return None
+
+
+def get_options_for_sensor(key: str) -> list[str] | None:
+    """Return the ENUM options for a bounded text sensor, else None."""
+    return ENUM_SENSOR_OPTIONS.get(key)
+
+
+def get_entity_category(key: str) -> EntityCategory | None:
+    """Return the entity category for a sensor.
+
+    Nominal capacity is a static hardware spec, not live telemetry -> diagnostic.
+    """
+    if key == "battery_capacity" or key.endswith("capacity"):
+        return EntityCategory.DIAGNOSTIC
+    return None
+
+
+def get_suggested_display_precision(key: str) -> int | None:
+    """Suggested number of decimals for a numeric sensor's displayed state."""
+    device_class = get_device_class_for_sensor(key)
+    unit = get_unit_for_sensor(key)
+    if device_class in (
+        SensorDeviceClass.ENERGY,
+        SensorDeviceClass.ENERGY_STORAGE,
+        SensorDeviceClass.MONETARY,
+    ):
+        return 2
+    if device_class == SensorDeviceClass.CURRENT:
+        return 2
+    if device_class in (SensorDeviceClass.POWER, SensorDeviceClass.VOLTAGE):
+        return 1
+    if device_class == SensorDeviceClass.BATTERY:
+        return 1
+    if device_class == SensorDeviceClass.DURATION:
+        return 0
+    if unit == UnitOfEnergy.KILO_WATT_HOUR:  # nominal capacity (no device class)
+        return 2
+    if unit == "ct/kWh":
+        return 2
+    if unit == PERCENTAGE:
+        return 1
+    return None
+
+
+def build_sensor_description(key: str, name: str) -> SensorEntityDescription:
+    """Build a SensorEntityDescription with all derived metadata for a key."""
+    return SensorEntityDescription(
+        key=key,
+        name=name,
+        device_class=get_device_class_for_sensor(key),
+        state_class=get_state_class_for_sensor(key),
+        native_unit_of_measurement=get_unit_for_sensor(key),
+        options=get_options_for_sensor(key),
+        suggested_display_precision=get_suggested_display_precision(key),
+        entity_category=get_entity_category(key),
+    )

--- a/custom_components/sunlit/sensor.py
+++ b/custom_components/sunlit/sensor.py
@@ -26,10 +26,8 @@ from .entities.battery_module_sensor import SunlitBatteryModuleSensor
 from .entities.battery_sensor import SunlitBatterySensor
 from .entities.family_sensor import SunlitFamilySensor
 from .entities.helpers import (
-    get_device_class_for_sensor,
+    build_sensor_description,
     get_icon_for_sensor,
-    get_state_class_for_sensor,
-    get_unit_for_sensor,
 )
 from .entities.inverter_sensor import SunlitInverterSensor
 from .entities.meter_sensor import SunlitMeterSensor
@@ -126,12 +124,8 @@ async def async_setup_entry(
 
                 for key in family_data:
                     if key in FAMILY_SENSORS and key not in skip_fields:
-                        sensor_description = SensorEntityDescription(
-                            key=key,
-                            name=FAMILY_SENSORS[key],
-                            device_class=get_device_class_for_sensor(key),
-                            state_class=get_state_class_for_sensor(key),
-                            native_unit_of_measurement=get_unit_for_sensor(key),
+                        sensor_description = build_sensor_description(
+                            key, FAMILY_SENSORS[key]
                         )
                         # Use appropriate coordinator based on data source
                         if key in [
@@ -207,13 +201,7 @@ async def async_setup_entry(
                         skip_device_fields = {"fault", "off"}
                         for key, name in sensor_map.items():
                             if key not in skip_device_fields:
-                                sensor_description = SensorEntityDescription(
-                                    key=key,
-                                    name=name,
-                                    device_class=get_device_class_for_sensor(key),
-                                    state_class=get_state_class_for_sensor(key),
-                                    native_unit_of_measurement=get_unit_for_sensor(key),
-                                )
+                                sensor_description = build_sensor_description(key, name)
                                 # Pass mppt_coordinator for battery devices
                                 extra_kwargs = {}
                                 if device_type == DEVICE_TYPE_BATTERY:
@@ -283,18 +271,8 @@ async def async_setup_entry(
                                 ) in BATTERY_MODULE_SENSORS.items():
                                     sensor_key = f"battery{module_num}{suffix}"
 
-                                    sensor_description = SensorEntityDescription(
-                                        key=sensor_key,
-                                        name=friendly_name,
-                                        device_class=get_device_class_for_sensor(
-                                            sensor_key
-                                        ),
-                                        state_class=get_state_class_for_sensor(
-                                            sensor_key
-                                        ),
-                                        native_unit_of_measurement=get_unit_for_sensor(
-                                            sensor_key
-                                        ),
+                                    sensor_description = build_sensor_description(
+                                        sensor_key, friendly_name
                                     )
 
                                     sensor = SunlitBatteryModuleSensor(

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -1,20 +1,24 @@
 """Tests for sensor helper functions."""
 
-import pytest
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
     PERCENTAGE,
+    EntityCategory,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
     UnitOfPower,
     UnitOfTime,
 )
+import pytest
 
 from custom_components.sunlit.entities.helpers import (
     get_device_class_for_sensor,
+    get_entity_category,
     get_icon_for_sensor,
+    get_options_for_sensor,
     get_state_class_for_sensor,
+    get_suggested_display_precision,
     get_unit_for_sensor,
 )
 
@@ -24,7 +28,10 @@ class TestDeviceClassForSensor:
 
     def test_timestamp_sensor(self):
         """Test that last_strategy_change returns timestamp device class."""
-        assert get_device_class_for_sensor("last_strategy_change") == SensorDeviceClass.TIMESTAMP
+        assert (
+            get_device_class_for_sensor("last_strategy_change")
+            == SensorDeviceClass.TIMESTAMP
+        )
 
     def test_energy_sensors(self):
         """Test energy sensor classification."""
@@ -38,11 +45,17 @@ class TestDeviceClassForSensor:
             "total_grid_export_energy",
             "daily_grid_export_energy",
             "daily_yield",
-            "battery_capacity",
             "batteryMppt1Energy",
         ]
         for sensor in energy_sensors:
-            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.ENERGY, f"Failed for {sensor}"
+            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.ENERGY, (
+                f"Failed for {sensor}"
+            )
+
+    def test_capacity_is_not_energy(self):
+        """Nominal capacity is a static spec, not metered energy (no device class)."""
+        assert get_device_class_for_sensor("battery_capacity") is None
+        assert get_device_class_for_sensor("battery1capacity") is None
 
     def test_power_sensors(self):
         """Test power sensor classification."""
@@ -59,23 +72,38 @@ class TestDeviceClassForSensor:
             "batteryMppt1InPower",
         ]
         for sensor in power_sensors:
-            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.POWER, f"Failed for {sensor}"
+            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.POWER, (
+                f"Failed for {sensor}"
+            )
 
     def test_battery_sensors(self):
-        """Test battery sensor classification."""
+        """Only metered, fluctuating SOC is BATTERY (issue: validate sensors)."""
         battery_sensors = [
             "battery_level",
             "average_battery_level",
             "batterySoc",
+            "battery1Soc",
+            "battery2Soc",
+        ]
+        for sensor in battery_sensors:
+            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.BATTERY, (
+                f"Failed for {sensor}"
+            )
+
+    def test_soc_limits_are_not_battery(self):
+        """SOC limit thresholds are config values, not metered battery levels."""
+        soc_limits = [
             "hw_soc_min",
             "hw_soc_max",
             "battery_soc_min",
             "battery_soc_max",
-            # Note: strategy_soc_min/max return None because "strategy" check comes first
-            # They are tested separately in test_strategy_fields_except_timestamp
+            "current_soc_min",
+            "current_soc_max",
+            "strategy_soc_min",
+            "strategy_soc_max",
         ]
-        for sensor in battery_sensors:
-            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.BATTERY, f"Failed for {sensor}"
+        for sensor in soc_limits:
+            assert get_device_class_for_sensor(sensor) is None, f"Failed for {sensor}"
 
     def test_duration_sensors(self):
         """Test duration sensor classification."""
@@ -86,7 +114,9 @@ class TestDeviceClassForSensor:
             "battery_discharging_remaining",
         ]
         for sensor in duration_sensors:
-            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.DURATION, f"Failed for {sensor}"
+            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.DURATION, (
+                f"Failed for {sensor}"
+            )
 
     def test_voltage_sensors(self):
         """Test voltage sensor classification."""
@@ -96,7 +126,9 @@ class TestDeviceClassForSensor:
             "battery1Mppt1InVol",
         ]
         for sensor in voltage_sensors:
-            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.VOLTAGE, f"Failed for {sensor}"
+            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.VOLTAGE, (
+                f"Failed for {sensor}"
+            )
 
     def test_current_sensors(self):
         """Test current sensor classification."""
@@ -106,11 +138,15 @@ class TestDeviceClassForSensor:
             "battery1Mppt1InCur",
         ]
         for sensor in current_sensors:
-            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.CURRENT, f"Failed for {sensor}"
+            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.CURRENT, (
+                f"Failed for {sensor}"
+            )
 
     def test_monetary_sensor(self):
         """Test monetary sensor classification."""
-        assert get_device_class_for_sensor("daily_earnings") == SensorDeviceClass.MONETARY
+        assert (
+            get_device_class_for_sensor("daily_earnings") == SensorDeviceClass.MONETARY
+        )
 
     def test_no_device_class_sensors(self):
         """Test sensors that should have no device class."""
@@ -140,7 +176,10 @@ class TestDeviceClassForSensor:
         assert get_device_class_for_sensor("strategy_soc_max") is None
 
         # But last_strategy_change should return TIMESTAMP (tested separately)
-        assert get_device_class_for_sensor("last_strategy_change") == SensorDeviceClass.TIMESTAMP
+        assert (
+            get_device_class_for_sensor("last_strategy_change")
+            == SensorDeviceClass.TIMESTAMP
+        )
 
 
 class TestStateClassForSensor:
@@ -155,7 +194,9 @@ class TestStateClassForSensor:
             "total_grid_export_energy",
         ]
         for sensor in total_increasing:
-            assert get_state_class_for_sensor(sensor) == SensorStateClass.TOTAL_INCREASING, f"Failed for {sensor}"
+            assert (
+                get_state_class_for_sensor(sensor) == SensorStateClass.TOTAL_INCREASING
+            ), f"Failed for {sensor}"
 
     def test_total_sensors(self):
         """Test sensors with total state class (daily counters)."""
@@ -168,7 +209,9 @@ class TestStateClassForSensor:
             "total_power_generation",  # Despite the name, this is daily data (resets at midnight)
         ]
         for sensor in total_sensors:
-            assert get_state_class_for_sensor(sensor) == SensorStateClass.TOTAL, f"Failed for {sensor}"
+            assert get_state_class_for_sensor(sensor) == SensorStateClass.TOTAL, (
+                f"Failed for {sensor}"
+            )
 
     def test_measurement_sensors(self):
         """Test sensors with measurement state class."""
@@ -188,7 +231,9 @@ class TestStateClassForSensor:
             "total_solar_power",
         ]
         for sensor in measurement_sensors:
-            assert get_state_class_for_sensor(sensor) == SensorStateClass.MEASUREMENT, f"Failed for {sensor}"
+            assert get_state_class_for_sensor(sensor) == SensorStateClass.MEASUREMENT, (
+                f"Failed for {sensor}"
+            )
 
     def test_no_state_class_sensors(self):
         """Test sensors that should have no state class."""
@@ -200,11 +245,17 @@ class TestStateClassForSensor:
             "last_strategy_status",
             "currency",
             "battery_count",
-            "rated_power",  # Configuration value
-            "max_output_power",  # Configuration value
         ]
         for sensor in no_state_class:
             assert get_state_class_for_sensor(sensor) is None, f"Failed for {sensor}"
+
+    def test_rated_and_max_power_have_measurement(self):
+        """rated_power / max_output_power are POWER sensors -> MEASUREMENT."""
+        assert get_state_class_for_sensor("rated_power") == SensorStateClass.MEASUREMENT
+        assert (
+            get_state_class_for_sensor("max_output_power")
+            == SensorStateClass.MEASUREMENT
+        )
 
 
 class TestUnitForSensor:
@@ -220,7 +271,9 @@ class TestUnitForSensor:
             "battery_capacity",
         ]
         for sensor in energy_sensors:
-            assert get_unit_for_sensor(sensor) == UnitOfEnergy.KILO_WATT_HOUR, f"Failed for {sensor}"
+            assert get_unit_for_sensor(sensor) == UnitOfEnergy.KILO_WATT_HOUR, (
+                f"Failed for {sensor}"
+            )
 
     def test_power_units(self):
         """Test power sensors return W."""
@@ -232,7 +285,9 @@ class TestUnitForSensor:
             "home_power",
         ]
         for sensor in power_sensors:
-            assert get_unit_for_sensor(sensor) == UnitOfPower.WATT, f"Failed for {sensor}"
+            assert get_unit_for_sensor(sensor) == UnitOfPower.WATT, (
+                f"Failed for {sensor}"
+            )
 
     def test_percentage_units(self):
         """Test battery/SOC sensors return %."""
@@ -254,7 +309,9 @@ class TestUnitForSensor:
             "battery_charging_remaining",
         ]
         for sensor in time_sensors:
-            assert get_unit_for_sensor(sensor) == UnitOfTime.MINUTES, f"Failed for {sensor}"
+            assert get_unit_for_sensor(sensor) == UnitOfTime.MINUTES, (
+                f"Failed for {sensor}"
+            )
 
     def test_voltage_units(self):
         """Test voltage sensors return V."""
@@ -263,7 +320,9 @@ class TestUnitForSensor:
             "batteryMppt2InVol",
         ]
         for sensor in voltage_sensors:
-            assert get_unit_for_sensor(sensor) == UnitOfElectricPotential.VOLT, f"Failed for {sensor}"
+            assert get_unit_for_sensor(sensor) == UnitOfElectricPotential.VOLT, (
+                f"Failed for {sensor}"
+            )
 
     def test_current_units(self):
         """Test current sensors return A."""
@@ -272,7 +331,9 @@ class TestUnitForSensor:
             "batteryMppt2InCur",
         ]
         for sensor in current_sensors:
-            assert get_unit_for_sensor(sensor) == UnitOfElectricCurrent.AMPERE, f"Failed for {sensor}"
+            assert get_unit_for_sensor(sensor) == UnitOfElectricCurrent.AMPERE, (
+                f"Failed for {sensor}"
+            )
 
     def test_monetary_units(self):
         """Test monetary sensor returns EUR."""
@@ -302,14 +363,23 @@ class TestIconForSensor:
 
     def test_solar_icons(self):
         """Test solar/inverter icons."""
-        assert get_icon_for_sensor("total_solar_energy") == "mdi:solar-power-variant-outline"
+        assert (
+            get_icon_for_sensor("total_solar_energy")
+            == "mdi:solar-power-variant-outline"
+        )
         assert get_icon_for_sensor("total_solar_power") == "mdi:solar-power-variant"
         assert get_icon_for_sensor("daily_yield") == "mdi:solar-power-variant"
 
     def test_grid_icons(self):
         """Test grid/meter icons."""
-        assert get_icon_for_sensor("total_grid_export_energy") == "mdi:transmission-tower-export"
-        assert get_icon_for_sensor("daily_grid_export_energy") == "mdi:transmission-tower-export"
+        assert (
+            get_icon_for_sensor("total_grid_export_energy")
+            == "mdi:transmission-tower-export"
+        )
+        assert (
+            get_icon_for_sensor("daily_grid_export_energy")
+            == "mdi:transmission-tower-export"
+        )
 
     def test_strategy_icons(self):
         """Test strategy-related icons."""
@@ -323,7 +393,9 @@ class TestIconForSensor:
         assert get_icon_for_sensor("chargeRemaining") == "mdi:timer-sand"
         # BUG: dischargeRemaining returns "mdi:timer-sand" instead of "mdi:timer-sand-empty"
         # because "charge" is checked before "discharge" and "charge" is in "discharge"
-        assert get_icon_for_sensor("dischargeRemaining") == "mdi:timer-sand"  # Current behavior
+        assert (
+            get_icon_for_sensor("dischargeRemaining") == "mdi:timer-sand"
+        )  # Current behavior
         # This should ideally be "mdi:timer-sand-empty" but needs fix in helpers.py
 
     def test_mppt_icons(self):
@@ -357,6 +429,51 @@ class TestLifetimeStatsSensors:
         assert get_icon_for_sensor("lifetime_earnings") == "mdi:cash"
 
 
+class TestSensorMetadataExtras:
+    """Validate entity_category, ENUM options, and display precision."""
+
+    @pytest.mark.parametrize("key", ["battery_capacity", "battery1capacity"])
+    def test_capacity_is_diagnostic(self, key):
+        """Nominal capacity is a static spec -> diagnostic, no device class."""
+        assert get_entity_category(key) == EntityCategory.DIAGNOSTIC
+        assert get_device_class_for_sensor(key) is None
+
+    def test_metered_sensors_are_not_diagnostic(self):
+        """Live telemetry stays in the default category."""
+        assert get_entity_category("batterySoc") is None
+        assert get_entity_category("stored_energy") is None
+
+    @pytest.mark.parametrize(
+        "key",
+        ["battery_device_status", "inverter_device_status", "meter_device_status"],
+    )
+    def test_device_status_is_enum(self, key):
+        """Device status is a bounded ENUM (no unit/state_class)."""
+        assert get_device_class_for_sensor(key) == SensorDeviceClass.ENUM
+        assert get_options_for_sensor(key) == ["Online", "Offline", "NotExist"]
+        assert get_unit_for_sensor(key) is None
+        assert get_state_class_for_sensor(key) is None
+
+    @pytest.mark.parametrize(
+        ("key", "precision"),
+        [
+            ("stored_energy", 2),
+            ("lifetime_yield", 2),
+            ("daily_earnings", 2),
+            ("batteryMppt1InPower", 1),
+            ("batteryMppt1InVol", 1),
+            ("batteryMppt1InCur", 2),
+            ("batterySoc", 1),
+            ("battery_capacity", 2),  # kWh, no device class
+            ("chargeRemaining", 0),
+            ("device_count", None),
+            ("battery_strategy", None),
+        ],
+    )
+    def test_suggested_display_precision(self, key, precision):
+        assert get_suggested_display_precision(key) == precision
+
+
 class TestStoredEnergySensors:
     """Test classification of battery stored-energy sensors (issue #190)."""
 
@@ -366,15 +483,15 @@ class TestStoredEnergySensors:
     )
     def test_stored_energy_classification(self, key):
         """Stored energy is ENERGY_STORAGE / MEASUREMENT / kWh."""
-        assert (
-            get_device_class_for_sensor(key) == SensorDeviceClass.ENERGY_STORAGE
-        ), f"Failed device_class for {key}"
-        assert (
-            get_state_class_for_sensor(key) == SensorStateClass.MEASUREMENT
-        ), f"Failed state_class for {key}"
-        assert (
-            get_unit_for_sensor(key) == UnitOfEnergy.KILO_WATT_HOUR
-        ), f"Failed unit for {key}"
+        assert get_device_class_for_sensor(key) == SensorDeviceClass.ENERGY_STORAGE, (
+            f"Failed device_class for {key}"
+        )
+        assert get_state_class_for_sensor(key) == SensorStateClass.MEASUREMENT, (
+            f"Failed state_class for {key}"
+        )
+        assert get_unit_for_sensor(key) == UnitOfEnergy.KILO_WATT_HOUR, (
+            f"Failed unit for {key}"
+        )
 
     def test_stored_energy_not_total_increasing(self):
         """Regression: stored energy must not be classified as a meter."""
@@ -403,10 +520,22 @@ class TestElectricityPriceSensors:
         assert get_icon_for_sensor(key) == "mdi:cash-multiple"
 
     def test_price_tag(self):
-        """The price tag is a plain text sensor."""
-        assert get_device_class_for_sensor("electricity_price_tag") is None
+        """The price tag is a bounded ENUM sensor (no unit/state_class)."""
+        from custom_components.sunlit.entities.helpers import get_options_for_sensor
+
+        assert (
+            get_device_class_for_sensor("electricity_price_tag")
+            == SensorDeviceClass.ENUM
+        )
         assert get_state_class_for_sensor("electricity_price_tag") is None
         assert get_unit_for_sensor("electricity_price_tag") is None
+        assert get_options_for_sensor("electricity_price_tag") == [
+            "VERY_CHEAP",
+            "CHEAP",
+            "NORMAL",
+            "EXPENSIVE",
+            "VERY_EXPENSIVE",
+        ]
         assert get_icon_for_sensor("electricity_price_tag") == "mdi:tag-outline"
 
 
@@ -434,9 +563,7 @@ class TestDeviceDiagnosticSensors:
 
     def test_diagnostic_icons_resolve_for_battery_device(self):
         """Icons must resolve before the battery device_type branch."""
-        assert (
-            get_icon_for_sensor("wifi_ssid", "ENERGY_STORAGE_BATTERY") == "mdi:wifi"
-        )
+        assert get_icon_for_sensor("wifi_ssid", "ENERGY_STORAGE_BATTERY") == "mdi:wifi"
         assert (
             get_icon_for_sensor("system_status", "ENERGY_STORAGE_BATTERY")
             == "mdi:information-outline"

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -3,19 +3,19 @@
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
-import pytest
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-from homeassistant.const import UnitOfEnergy, UnitOfPower
+from homeassistant.const import EntityCategory, UnitOfEnergy, UnitOfPower
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
+import pytest
 
-from custom_components.sunlit.coordinators.family import SunlitFamilyCoordinator
+from custom_components.sunlit.const import DOMAIN
 from custom_components.sunlit.coordinators.device import SunlitDeviceCoordinator
+from custom_components.sunlit.coordinators.family import SunlitFamilyCoordinator
+from custom_components.sunlit.coordinators.mppt import SunlitMpptEnergyCoordinator
 from custom_components.sunlit.coordinators.strategy import (
     SunlitStrategyHistoryCoordinator,
 )
-from custom_components.sunlit.coordinators.mppt import SunlitMpptEnergyCoordinator
-from custom_components.sunlit.const import DOMAIN
 from custom_components.sunlit.sensor import async_setup_entry
 from tests.test_utils import assert_sensors
 
@@ -54,7 +54,9 @@ def mock_coordinators():
     device_coordinator = MagicMock(spec=SunlitDeviceCoordinator)
     device_coordinator.family_id = "test_family_123"
     device_coordinator.family_name = "Test Family"
-    device_coordinator.get_battery_module_count.return_value = 3  # Mock dynamic module count
+    device_coordinator.get_battery_module_count.return_value = (
+        3  # Mock dynamic module count
+    )
     device_coordinator.data = {
         "devices": {
             "meter_001": {
@@ -193,13 +195,16 @@ async def test_family_sensor_creation(
             == UnitOfEnergy.KILO_WATT_HOUR
         )
 
-    # Check battery sensor
+    # Check battery sensor (metered SOC -> MEASUREMENT for long-term statistics)
     if "average_battery_level" in sensor_map:
         battery_sensor = sensor_map["average_battery_level"]
         assert (
             battery_sensor.entity_description.device_class == SensorDeviceClass.BATTERY
         )
-        assert battery_sensor.entity_description.state_class is None
+        assert (
+            battery_sensor.entity_description.state_class
+            == SensorStateClass.MEASUREMENT
+        )
         assert battery_sensor.entity_description.native_unit_of_measurement == "%"
 
 
@@ -326,9 +331,9 @@ async def test_timestamp_sensor_value(
     # Verify it's approximately 2 hours ago (within 1 minute tolerance)
     now = datetime.now()
     time_diff = now.timestamp() - value.timestamp()
-    assert (
-        7100 < time_diff < 7300
-    ), f"Timestamp should be ~2 hours ago, but diff is {time_diff} seconds"
+    assert 7100 < time_diff < 7300, (
+        f"Timestamp should be ~2 hours ago, but diff is {time_diff} seconds"
+    )
 
 
 async def test_sensor_count(
@@ -371,12 +376,13 @@ async def test_meter_device_sensor_creation(
     mock_config_entry,
 ):
     """Test that meter devices create the correct sensors."""
-    from custom_components.sunlit.entities.meter_sensor import SunlitMeterSensor
     from custom_components.sunlit.const import (
         DEVICE_TYPE_METER,
         DEVICE_TYPE_METER_PRO,
         METER_SENSORS,
     )
+    from custom_components.sunlit.entities.meter_sensor import SunlitMeterSensor
+
     from .test_utils import assert_sensors
 
     # Create specialized coordinators for meter test
@@ -388,7 +394,9 @@ async def test_meter_device_sensor_creation(
     device_coordinator = MagicMock(spec=SunlitDeviceCoordinator)
     device_coordinator.family_id = "test_family_123"
     device_coordinator.family_name = "Test Family"
-    device_coordinator.get_battery_module_count.return_value = 3  # Mock dynamic module count
+    device_coordinator.get_battery_module_count.return_value = (
+        3  # Mock dynamic module count
+    )
     device_coordinator.data = {
         "devices": {
             "meter_001": {
@@ -434,43 +442,55 @@ async def test_meter_device_sensor_creation(
         expected_keys = set(METER_SENSORS.keys()) | {"status"}
         expected_count = len(METER_SENSORS) + 1  # +1 for status
 
-        (assert_sensors(sensors)
-         .for_device("meter_001")
-         .with_count(expected_count)
-         .having_keys(expected_keys)
-         .with_sensor_class(SunlitMeterSensor))
+        (
+            assert_sensors(sensors)
+            .for_device("meter_001")
+            .with_count(expected_count)
+            .having_keys(expected_keys)
+            .with_sensor_class(SunlitMeterSensor)
+        )
 
         # Test specific sensor attributes with fluent API
-        (assert_sensors(sensors)
-         .for_device("meter_001")
-         .where_key("total_ac_power")
-         .matches_pattern(
-             device_class=SensorDeviceClass.POWER,
-             state_class=SensorStateClass.MEASUREMENT,
-             unit=UnitOfPower.WATT
-         ))
+        (
+            assert_sensors(sensors)
+            .for_device("meter_001")
+            .where_key("total_ac_power")
+            .matches_pattern(
+                device_class=SensorDeviceClass.POWER,
+                state_class=SensorStateClass.MEASUREMENT,
+                unit=UnitOfPower.WATT,
+            )
+        )
 
-        (assert_sensors(sensors)
-         .for_device("meter_001")
-         .where_key_contains("energy")
-         .has_device_class(SensorDeviceClass.ENERGY)
-         .has_unit(UnitOfEnergy.KILO_WATT_HOUR))
+        (
+            assert_sensors(sensors)
+            .for_device("meter_001")
+            .where_key_contains("energy")
+            .has_device_class(SensorDeviceClass.ENERGY)
+            .has_unit(UnitOfEnergy.KILO_WATT_HOUR)
+        )
 
-        (assert_sensors(sensors)
-         .for_device("meter_001")
-         .where_key_matches(lambda k: "daily" in k and "energy" in k)
-         .has_state_class(SensorStateClass.TOTAL))
+        (
+            assert_sensors(sensors)
+            .for_device("meter_001")
+            .where_key_matches(lambda k: "daily" in k and "energy" in k)
+            .has_state_class(SensorStateClass.TOTAL)
+        )
 
-        (assert_sensors(sensors)
-         .for_device("meter_001")
-         .where_key_matches(lambda k: "total" in k and "energy" in k)
-         .has_state_class(SensorStateClass.TOTAL_INCREASING))
+        (
+            assert_sensors(sensors)
+            .for_device("meter_001")
+            .where_key_matches(lambda k: "total" in k and "energy" in k)
+            .has_state_class(SensorStateClass.TOTAL_INCREASING)
+        )
 
-        (assert_sensors(sensors)
-         .for_device("meter_001")
-         .where_key("status")
-         .has_no_device_class()
-         .has_no_unit())
+        (
+            assert_sensors(sensors)
+            .for_device("meter_001")
+            .where_key("status")
+            .has_no_device_class()
+            .has_no_unit()
+        )
 
         # Clean up for next iteration
         hass.data[DOMAIN] = {}
@@ -483,8 +503,8 @@ async def test_battery_device_sensor_creation(
     mock_config_entry,
 ):
     """Test that battery devices create the correct sensors."""
+    from custom_components.sunlit.const import BATTERY_SENSORS, DEVICE_TYPE_BATTERY
     from custom_components.sunlit.entities.battery_sensor import SunlitBatterySensor
-    from custom_components.sunlit.const import DEVICE_TYPE_BATTERY, BATTERY_SENSORS
 
     # Create specialized coordinators for battery test
     family_coordinator = MagicMock(spec=SunlitFamilyCoordinator)
@@ -495,7 +515,9 @@ async def test_battery_device_sensor_creation(
     device_coordinator = MagicMock(spec=SunlitDeviceCoordinator)
     device_coordinator.family_id = "test_family_123"
     device_coordinator.family_name = "Test Family"
-    device_coordinator.get_battery_module_count.return_value = 3  # Mock dynamic module count
+    device_coordinator.get_battery_module_count.return_value = (
+        3  # Mock dynamic module count
+    )
     device_coordinator.data = {
         "devices": {
             "battery_001": {
@@ -548,87 +570,108 @@ async def test_battery_device_sensor_creation(
     # Test battery device sensors using builder pattern
     expected_battery_keys = set(BATTERY_SENSORS.keys()) | {"status"}
 
-    (assert_sensors(sensors)
-     .for_device("battery_001")
-     .excluding_modules()  # Exclude battery module sensors
-     .with_count(len(BATTERY_SENSORS) + 1)  # +1 for status sensor
-     .having_keys(expected_battery_keys)
-     .with_sensor_class(SunlitBatterySensor))
+    (
+        assert_sensors(sensors)
+        .for_device("battery_001")
+        .excluding_modules()  # Exclude battery module sensors
+        .with_count(len(BATTERY_SENSORS) + 1)  # +1 for status sensor
+        .having_keys(expected_battery_keys)
+        .with_sensor_class(SunlitBatterySensor)
+    )
 
     # Test specific sensor patterns
-    (assert_sensors(sensors)
-     .for_device("battery_001")
-     .excluding_modules()
-     .where_key_contains("Remaining")
-     .matches_pattern(
-         device_class=SensorDeviceClass.DURATION,
-         unit="min"
-     ))
+    (
+        assert_sensors(sensors)
+        .for_device("battery_001")
+        .excluding_modules()
+        .where_key_contains("Remaining")
+        .matches_pattern(device_class=SensorDeviceClass.DURATION, unit="min")
+    )
 
-    (assert_sensors(sensors)
-     .for_device("battery_001")
-     .excluding_modules()
-     .where_key_matches(lambda k: k in ["battery_level", "batterySoc"])
-     .matches_pattern(
-         device_class=SensorDeviceClass.BATTERY,
-         unit="%"
-     ))
+    (
+        assert_sensors(sensors)
+        .for_device("battery_001")
+        .excluding_modules()
+        .where_key_matches(lambda k: k in ["battery_level", "batterySoc"])
+        .matches_pattern(device_class=SensorDeviceClass.BATTERY, unit="%")
+    )
 
-    (assert_sensors(sensors)
-     .for_device("battery_001")
-     .excluding_modules()
-     .where_key_contains("InVol")
-     .matches_pattern(
-         device_class=SensorDeviceClass.VOLTAGE,
-         unit="V"
-     ))
+    (
+        assert_sensors(sensors)
+        .for_device("battery_001")
+        .excluding_modules()
+        .where_key_contains("InVol")
+        .matches_pattern(device_class=SensorDeviceClass.VOLTAGE, unit="V")
+    )
 
-    (assert_sensors(sensors)
-     .for_device("battery_001")
-     .excluding_modules()
-     .where_key_contains("InCur")
-     .matches_pattern(
-         device_class=SensorDeviceClass.CURRENT,
-         unit="A"
-     ))
+    (
+        assert_sensors(sensors)
+        .for_device("battery_001")
+        .excluding_modules()
+        .where_key_contains("InCur")
+        .matches_pattern(device_class=SensorDeviceClass.CURRENT, unit="A")
+    )
 
-    (assert_sensors(sensors)
-     .for_device("battery_001")
-     .excluding_modules()
-     .where_key_matches(lambda k: "power" in k.lower())
-     .matches_pattern(
-         device_class=SensorDeviceClass.POWER,
-         unit=UnitOfPower.WATT
-     ))
+    (
+        assert_sensors(sensors)
+        .for_device("battery_001")
+        .excluding_modules()
+        .where_key_matches(lambda k: "power" in k.lower())
+        .matches_pattern(device_class=SensorDeviceClass.POWER, unit=UnitOfPower.WATT)
+    )
 
-    (assert_sensors(sensors)
-     .for_device("battery_001")
-     .excluding_modules()
-     .where_key_matches(
-         lambda k: ("energy" in k.lower() and "stored" not in k.lower())
-         or k == "battery_capacity"
-     )
-     .matches_pattern(
-         device_class=SensorDeviceClass.ENERGY,
-         unit=UnitOfEnergy.KILO_WATT_HOUR
-     ))
+    (
+        assert_sensors(sensors)
+        .for_device("battery_001")
+        .excluding_modules()
+        .where_key_matches(
+            lambda k: (
+                "energy" in k.lower()
+                and "stored" not in k.lower()
+                and "capacity" not in k.lower()
+            )
+        )
+        .matches_pattern(
+            device_class=SensorDeviceClass.ENERGY, unit=UnitOfEnergy.KILO_WATT_HOUR
+        )
+    )
+
+    # Nominal capacity: static spec -> no device class, diagnostic (issue: validate)
+    capacity_sensor = next(
+        s
+        for s in sensors
+        if getattr(s, "_device_id", None) == "battery_001"
+        and s.entity_description.key == "battery_capacity"
+    )
+    assert capacity_sensor.entity_description.device_class is None
+    assert (
+        capacity_sensor.entity_description.entity_category == EntityCategory.DIAGNOSTIC
+    )
+    assert (
+        capacity_sensor.entity_description.native_unit_of_measurement
+        == UnitOfEnergy.KILO_WATT_HOUR
+    )
 
     # Stored energy is ENERGY_STORAGE (the battery level), not ENERGY (issue #190)
-    (assert_sensors(sensors)
-     .for_device("battery_001")
-     .excluding_modules()
-     .where_key("stored_energy")
-     .matches_pattern(
-         device_class=SensorDeviceClass.ENERGY_STORAGE,
-         unit=UnitOfEnergy.KILO_WATT_HOUR
-     ))
+    (
+        assert_sensors(sensors)
+        .for_device("battery_001")
+        .excluding_modules()
+        .where_key("stored_energy")
+        .matches_pattern(
+            device_class=SensorDeviceClass.ENERGY_STORAGE,
+            unit=UnitOfEnergy.KILO_WATT_HOUR,
+        )
+    )
 
-    (assert_sensors(sensors)
-     .for_device("battery_001")
-     .excluding_modules()
-     .where_key("status")
-     .has_no_device_class()
-     .has_no_unit())
+    (
+        assert_sensors(sensors)
+        .for_device("battery_001")
+        .excluding_modules()
+        .where_key("status")
+        .has_no_device_class()
+        .has_no_unit()
+    )
 
 
 async def test_battery_module_sensor_creation(
@@ -637,12 +680,12 @@ async def test_battery_module_sensor_creation(
     mock_config_entry,
 ):
     """Test that battery devices create virtual battery module sensors."""
+    from custom_components.sunlit.const import (
+        BATTERY_MODULE_SENSORS,
+        DEVICE_TYPE_BATTERY,
+    )
     from custom_components.sunlit.entities.battery_module_sensor import (
         SunlitBatteryModuleSensor,
-    )
-    from custom_components.sunlit.const import (
-        DEVICE_TYPE_BATTERY,
-        BATTERY_MODULE_SENSORS,
     )
 
     # Create specialized coordinators for battery module test
@@ -654,7 +697,9 @@ async def test_battery_module_sensor_creation(
     device_coordinator = MagicMock(spec=SunlitDeviceCoordinator)
     device_coordinator.family_id = "test_family_123"
     device_coordinator.family_name = "Test Family"
-    device_coordinator.get_battery_module_count.return_value = 3  # Mock dynamic module count
+    device_coordinator.get_battery_module_count.return_value = (
+        3  # Mock dynamic module count
+    )
     device_coordinator.data = {
         "devices": {
             "battery_001": {
@@ -724,17 +769,17 @@ async def test_battery_module_sensor_creation(
     # We need to get the actual module count from the test device
     test_module_count = 3  # Based on our test fixture deviceCount
     expected_module_count = test_module_count * len(BATTERY_MODULE_SENSORS)
-    assert (
-        len(battery_module_sensors) == expected_module_count
-    ), f"Expected {expected_module_count} battery module sensors, got {len(battery_module_sensors)}"
+    assert len(battery_module_sensors) == expected_module_count, (
+        f"Expected {expected_module_count} battery module sensors, got {len(battery_module_sensors)}"
+    )
 
     # Verify sensor classes
     module_class_sensors = [
         s for s in battery_module_sensors if isinstance(s, SunlitBatteryModuleSensor)
     ]
-    assert len(module_class_sensors) == len(
-        battery_module_sensors
-    ), f"All battery module sensors should use SunlitBatteryModuleSensor class"
+    assert len(module_class_sensors) == len(battery_module_sensors), (
+        f"All battery module sensors should use SunlitBatteryModuleSensor class"
+    )
 
     # Verify each module has the correct sensors
     for module_num in [1, 2, 3]:
@@ -743,9 +788,9 @@ async def test_battery_module_sensor_creation(
             for s in battery_module_sensors
             if hasattr(s, "_module_number") and s._module_number == module_num
         ]
-        assert len(module_sensors) == len(
-            BATTERY_MODULE_SENSORS
-        ), f"Module {module_num} should have {len(BATTERY_MODULE_SENSORS)} sensors"
+        assert len(module_sensors) == len(BATTERY_MODULE_SENSORS), (
+            f"Module {module_num} should have {len(BATTERY_MODULE_SENSORS)} sensors"
+        )
 
         # Verify sensor keys for this module
         module_sensor_keys = {
@@ -756,9 +801,9 @@ async def test_battery_module_sensor_creation(
         expected_module_keys = {
             f"battery{module_num}{suffix}" for suffix in BATTERY_MODULE_SENSORS.keys()
         }
-        assert (
-            module_sensor_keys == expected_module_keys
-        ), f"Module {module_num} expected keys {expected_module_keys}, got {module_sensor_keys}"
+        assert module_sensor_keys == expected_module_keys, (
+            f"Module {module_num} expected keys {expected_module_keys}, got {module_sensor_keys}"
+        )
 
     # Verify specific sensor attributes for battery modules
     for sensor in battery_module_sensors:
@@ -795,7 +840,18 @@ async def test_battery_module_sensor_creation(
                     sensor.entity_description.native_unit_of_measurement
                     == UnitOfEnergy.KILO_WATT_HOUR
                 )
-            elif "Energy" in key or "capacity" in key:
+            elif "capacity" in key:
+                # Nominal capacity: static spec -> no device class, diagnostic.
+                assert sensor.entity_description.device_class is None
+                assert (
+                    sensor.entity_description.entity_category
+                    == EntityCategory.DIAGNOSTIC
+                )
+                assert (
+                    sensor.entity_description.native_unit_of_measurement
+                    == UnitOfEnergy.KILO_WATT_HOUR
+                )
+            elif "Energy" in key:
                 assert (
                     sensor.entity_description.device_class == SensorDeviceClass.ENERGY
                 )
@@ -824,7 +880,9 @@ async def test_unknown_device_sensor_creation(
     device_coordinator = MagicMock(spec=SunlitDeviceCoordinator)
     device_coordinator.family_id = "test_family_123"
     device_coordinator.family_name = "Test Family"
-    device_coordinator.get_battery_module_count.return_value = 3  # Mock dynamic module count
+    device_coordinator.get_battery_module_count.return_value = (
+        3  # Mock dynamic module count
+    )
     device_coordinator.data = {
         "devices": {
             "unknown_001": {
@@ -867,17 +925,17 @@ async def test_unknown_device_sensor_creation(
     ]
 
     # Should have only status sensor (no device-specific sensors for unknown devices)
-    assert (
-        len(unknown_sensors) == 1
-    ), f"Expected 1 unknown device sensor (status only), got {len(unknown_sensors)}"
+    assert len(unknown_sensors) == 1, (
+        f"Expected 1 unknown device sensor (status only), got {len(unknown_sensors)}"
+    )
 
     # Verify sensor class
     unknown_class_sensors = [
         s for s in unknown_sensors if isinstance(s, SunlitUnknownDeviceSensor)
     ]
-    assert len(unknown_class_sensors) == len(
-        unknown_sensors
-    ), f"All unknown device sensors should use SunlitUnknownDeviceSensor class"
+    assert len(unknown_class_sensors) == len(unknown_sensors), (
+        f"All unknown device sensors should use SunlitUnknownDeviceSensor class"
+    )
 
     # Verify it's the status sensor
     status_sensor = unknown_sensors[0]
@@ -891,20 +949,20 @@ async def test_device_type_sensor_mapping(
     enable_custom_integrations,
 ):
     """Test the create_device_sensor factory function with different device types."""
-    from custom_components.sunlit.sensor import create_device_sensor
-    from custom_components.sunlit.entities.meter_sensor import SunlitMeterSensor
-    from custom_components.sunlit.entities.inverter_sensor import SunlitInverterSensor
+    from custom_components.sunlit.const import (
+        DEVICE_TYPE_BATTERY,
+        DEVICE_TYPE_INVERTER,
+        DEVICE_TYPE_INVERTER_SOLAR,
+        DEVICE_TYPE_METER,
+        DEVICE_TYPE_METER_PRO,
+    )
     from custom_components.sunlit.entities.battery_sensor import SunlitBatterySensor
+    from custom_components.sunlit.entities.inverter_sensor import SunlitInverterSensor
+    from custom_components.sunlit.entities.meter_sensor import SunlitMeterSensor
     from custom_components.sunlit.entities.unknown_device_sensor import (
         SunlitUnknownDeviceSensor,
     )
-    from custom_components.sunlit.const import (
-        DEVICE_TYPE_METER,
-        DEVICE_TYPE_METER_PRO,
-        DEVICE_TYPE_INVERTER,
-        DEVICE_TYPE_INVERTER_SOLAR,
-        DEVICE_TYPE_BATTERY,
-    )
+    from custom_components.sunlit.sensor import create_device_sensor
 
     # Test data for sensor creation
     test_kwargs = {
@@ -919,39 +977,39 @@ async def test_device_type_sensor_mapping(
 
     # Test meter device types
     meter_sensor = create_device_sensor(DEVICE_TYPE_METER, **test_kwargs)
-    assert isinstance(
-        meter_sensor, SunlitMeterSensor
-    ), f"Expected SunlitMeterSensor, got {type(meter_sensor)}"
+    assert isinstance(meter_sensor, SunlitMeterSensor), (
+        f"Expected SunlitMeterSensor, got {type(meter_sensor)}"
+    )
 
     meter_pro_sensor = create_device_sensor(DEVICE_TYPE_METER_PRO, **test_kwargs)
-    assert isinstance(
-        meter_pro_sensor, SunlitMeterSensor
-    ), f"Expected SunlitMeterSensor, got {type(meter_pro_sensor)}"
+    assert isinstance(meter_pro_sensor, SunlitMeterSensor), (
+        f"Expected SunlitMeterSensor, got {type(meter_pro_sensor)}"
+    )
 
     # Test inverter device types
     inverter_sensor = create_device_sensor(DEVICE_TYPE_INVERTER, **test_kwargs)
-    assert isinstance(
-        inverter_sensor, SunlitInverterSensor
-    ), f"Expected SunlitInverterSensor, got {type(inverter_sensor)}"
+    assert isinstance(inverter_sensor, SunlitInverterSensor), (
+        f"Expected SunlitInverterSensor, got {type(inverter_sensor)}"
+    )
 
     inverter_solar_sensor = create_device_sensor(
         DEVICE_TYPE_INVERTER_SOLAR, **test_kwargs
     )
-    assert isinstance(
-        inverter_solar_sensor, SunlitInverterSensor
-    ), f"Expected SunlitInverterSensor, got {type(inverter_solar_sensor)}"
+    assert isinstance(inverter_solar_sensor, SunlitInverterSensor), (
+        f"Expected SunlitInverterSensor, got {type(inverter_solar_sensor)}"
+    )
 
     # Test battery device type
     battery_sensor = create_device_sensor(DEVICE_TYPE_BATTERY, **test_kwargs)
-    assert isinstance(
-        battery_sensor, SunlitBatterySensor
-    ), f"Expected SunlitBatterySensor, got {type(battery_sensor)}"
+    assert isinstance(battery_sensor, SunlitBatterySensor), (
+        f"Expected SunlitBatterySensor, got {type(battery_sensor)}"
+    )
 
     # Test unknown device type (fallback)
     unknown_sensor = create_device_sensor("UNKNOWN_TYPE", **test_kwargs)
-    assert isinstance(
-        unknown_sensor, SunlitUnknownDeviceSensor
-    ), f"Expected SunlitUnknownDeviceSensor, got {type(unknown_sensor)}"
+    assert isinstance(unknown_sensor, SunlitUnknownDeviceSensor), (
+        f"Expected SunlitUnknownDeviceSensor, got {type(unknown_sensor)}"
+    )
 
 
 async def test_inverter_device_sensor_creation(
@@ -960,12 +1018,13 @@ async def test_inverter_device_sensor_creation(
     mock_config_entry,
 ):
     """Test that inverter devices create the correct sensors."""
-    from custom_components.sunlit.entities.inverter_sensor import SunlitInverterSensor
     from custom_components.sunlit.const import (
         DEVICE_TYPE_INVERTER,
         DEVICE_TYPE_INVERTER_SOLAR,
         INVERTER_SENSORS,
     )
+    from custom_components.sunlit.entities.inverter_sensor import SunlitInverterSensor
+
     from .test_utils import assert_sensors
 
     # Create specialized coordinators for inverter test
@@ -977,7 +1036,9 @@ async def test_inverter_device_sensor_creation(
     device_coordinator = MagicMock(spec=SunlitDeviceCoordinator)
     device_coordinator.family_id = "test_family_123"
     device_coordinator.family_name = "Test Family"
-    device_coordinator.get_battery_module_count.return_value = 3  # Mock dynamic module count
+    device_coordinator.get_battery_module_count.return_value = (
+        3  # Mock dynamic module count
+    )
     device_coordinator.data = {
         "devices": {
             "inverter_001": {
@@ -1022,55 +1083,64 @@ async def test_inverter_device_sensor_creation(
         expected_keys = set(INVERTER_SENSORS.keys()) | {"status"}
         expected_count = len(INVERTER_SENSORS) + 1  # +1 for status
 
-        (assert_sensors(sensors)
-         .for_device("inverter_001")
-         .with_count(expected_count)
-         .having_keys(expected_keys)
-         .with_sensor_class(SunlitInverterSensor))
+        (
+            assert_sensors(sensors)
+            .for_device("inverter_001")
+            .with_count(expected_count)
+            .having_keys(expected_keys)
+            .with_sensor_class(SunlitInverterSensor)
+        )
 
         # Test specific sensor attributes with fluent API
-        (assert_sensors(sensors)
-         .for_device("inverter_001")
-         .where_key("current_power")
-         .matches_pattern(
-             device_class=SensorDeviceClass.POWER,
-             state_class=SensorStateClass.MEASUREMENT,
-             unit=UnitOfPower.WATT
-         ))
+        (
+            assert_sensors(sensors)
+            .for_device("inverter_001")
+            .where_key("current_power")
+            .matches_pattern(
+                device_class=SensorDeviceClass.POWER,
+                state_class=SensorStateClass.MEASUREMENT,
+                unit=UnitOfPower.WATT,
+            )
+        )
 
         # total_power_generation is daily data (resets at midnight)
-        (assert_sensors(sensors)
-         .for_device("inverter_001")
-         .where_key("total_power_generation")
-         .matches_pattern(
-             device_class=SensorDeviceClass.ENERGY,
-             state_class=SensorStateClass.TOTAL,
-             unit=UnitOfEnergy.KILO_WATT_HOUR
-         ))
+        (
+            assert_sensors(sensors)
+            .for_device("inverter_001")
+            .where_key("total_power_generation")
+            .matches_pattern(
+                device_class=SensorDeviceClass.ENERGY,
+                state_class=SensorStateClass.TOTAL,
+                unit=UnitOfEnergy.KILO_WATT_HOUR,
+            )
+        )
 
         # total_yield is lifetime cumulative data
-        (assert_sensors(sensors)
-         .for_device("inverter_001")
-         .where_key("total_yield")
-         .matches_pattern(
-             device_class=SensorDeviceClass.ENERGY,
-             state_class=SensorStateClass.TOTAL_INCREASING,
-             unit=UnitOfEnergy.KILO_WATT_HOUR
-         ))
+        (
+            assert_sensors(sensors)
+            .for_device("inverter_001")
+            .where_key("total_yield")
+            .matches_pattern(
+                device_class=SensorDeviceClass.ENERGY,
+                state_class=SensorStateClass.TOTAL_INCREASING,
+                unit=UnitOfEnergy.KILO_WATT_HOUR,
+            )
+        )
 
-        (assert_sensors(sensors)
-         .for_device("inverter_001")
-         .where_key("daily_earnings")
-         .matches_pattern(
-             device_class=SensorDeviceClass.MONETARY,
-             unit="EUR"
-         ))
+        (
+            assert_sensors(sensors)
+            .for_device("inverter_001")
+            .where_key("daily_earnings")
+            .matches_pattern(device_class=SensorDeviceClass.MONETARY, unit="EUR")
+        )
 
-        (assert_sensors(sensors)
-         .for_device("inverter_001")
-         .where_key("status")
-         .has_no_device_class()
-         .has_no_unit())
+        (
+            assert_sensors(sensors)
+            .for_device("inverter_001")
+            .where_key("status")
+            .has_no_device_class()
+            .has_no_unit()
+        )
 
         # Clean up for next iteration
         hass.data[DOMAIN] = {}
@@ -1083,12 +1153,12 @@ async def test_battery_module_sensor_creation(
     mock_config_entry,
 ):
     """Test that battery devices create virtual battery module sensors."""
+    from custom_components.sunlit.const import (
+        BATTERY_MODULE_SENSORS,
+        DEVICE_TYPE_BATTERY,
+    )
     from custom_components.sunlit.entities.battery_module_sensor import (
         SunlitBatteryModuleSensor,
-    )
-    from custom_components.sunlit.const import (
-        DEVICE_TYPE_BATTERY,
-        BATTERY_MODULE_SENSORS,
     )
 
     # Create specialized coordinators for battery module test
@@ -1100,7 +1170,9 @@ async def test_battery_module_sensor_creation(
     device_coordinator = MagicMock(spec=SunlitDeviceCoordinator)
     device_coordinator.family_id = "test_family_123"
     device_coordinator.family_name = "Test Family"
-    device_coordinator.get_battery_module_count.return_value = 3  # Mock dynamic module count
+    device_coordinator.get_battery_module_count.return_value = (
+        3  # Mock dynamic module count
+    )
     device_coordinator.data = {
         "devices": {
             "battery_001": {
@@ -1170,17 +1242,17 @@ async def test_battery_module_sensor_creation(
     # We need to get the actual module count from the test device
     test_module_count = 3  # Based on our test fixture deviceCount
     expected_module_count = test_module_count * len(BATTERY_MODULE_SENSORS)
-    assert (
-        len(battery_module_sensors) == expected_module_count
-    ), f"Expected {expected_module_count} battery module sensors, got {len(battery_module_sensors)}"
+    assert len(battery_module_sensors) == expected_module_count, (
+        f"Expected {expected_module_count} battery module sensors, got {len(battery_module_sensors)}"
+    )
 
     # Verify sensor classes
     module_class_sensors = [
         s for s in battery_module_sensors if isinstance(s, SunlitBatteryModuleSensor)
     ]
-    assert len(module_class_sensors) == len(
-        battery_module_sensors
-    ), f"All battery module sensors should use SunlitBatteryModuleSensor class"
+    assert len(module_class_sensors) == len(battery_module_sensors), (
+        f"All battery module sensors should use SunlitBatteryModuleSensor class"
+    )
 
     # Verify each module has the correct sensors
     for module_num in [1, 2, 3]:
@@ -1189,9 +1261,9 @@ async def test_battery_module_sensor_creation(
             for s in battery_module_sensors
             if hasattr(s, "_module_number") and s._module_number == module_num
         ]
-        assert len(module_sensors) == len(
-            BATTERY_MODULE_SENSORS
-        ), f"Module {module_num} should have {len(BATTERY_MODULE_SENSORS)} sensors"
+        assert len(module_sensors) == len(BATTERY_MODULE_SENSORS), (
+            f"Module {module_num} should have {len(BATTERY_MODULE_SENSORS)} sensors"
+        )
 
         # Verify sensor keys for this module
         module_sensor_keys = {
@@ -1202,9 +1274,9 @@ async def test_battery_module_sensor_creation(
         expected_module_keys = {
             f"battery{module_num}{suffix}" for suffix in BATTERY_MODULE_SENSORS.keys()
         }
-        assert (
-            module_sensor_keys == expected_module_keys
-        ), f"Module {module_num} expected keys {expected_module_keys}, got {module_sensor_keys}"
+        assert module_sensor_keys == expected_module_keys, (
+            f"Module {module_num} expected keys {expected_module_keys}, got {module_sensor_keys}"
+        )
 
     # Verify specific sensor attributes for battery modules
     for sensor in battery_module_sensors:
@@ -1241,7 +1313,18 @@ async def test_battery_module_sensor_creation(
                     sensor.entity_description.native_unit_of_measurement
                     == UnitOfEnergy.KILO_WATT_HOUR
                 )
-            elif "Energy" in key or "capacity" in key:
+            elif "capacity" in key:
+                # Nominal capacity: static spec -> no device class, diagnostic.
+                assert sensor.entity_description.device_class is None
+                assert (
+                    sensor.entity_description.entity_category
+                    == EntityCategory.DIAGNOSTIC
+                )
+                assert (
+                    sensor.entity_description.native_unit_of_measurement
+                    == UnitOfEnergy.KILO_WATT_HOUR
+                )
+            elif "Energy" in key:
                 assert (
                     sensor.entity_description.device_class == SensorDeviceClass.ENERGY
                 )
@@ -1270,7 +1353,9 @@ async def test_unknown_device_sensor_creation(
     device_coordinator = MagicMock(spec=SunlitDeviceCoordinator)
     device_coordinator.family_id = "test_family_123"
     device_coordinator.family_name = "Test Family"
-    device_coordinator.get_battery_module_count.return_value = 3  # Mock dynamic module count
+    device_coordinator.get_battery_module_count.return_value = (
+        3  # Mock dynamic module count
+    )
     device_coordinator.data = {
         "devices": {
             "unknown_001": {
@@ -1313,17 +1398,17 @@ async def test_unknown_device_sensor_creation(
     ]
 
     # Should have only status sensor (no device-specific sensors for unknown devices)
-    assert (
-        len(unknown_sensors) == 1
-    ), f"Expected 1 unknown device sensor (status only), got {len(unknown_sensors)}"
+    assert len(unknown_sensors) == 1, (
+        f"Expected 1 unknown device sensor (status only), got {len(unknown_sensors)}"
+    )
 
     # Verify sensor class
     unknown_class_sensors = [
         s for s in unknown_sensors if isinstance(s, SunlitUnknownDeviceSensor)
     ]
-    assert len(unknown_class_sensors) == len(
-        unknown_sensors
-    ), f"All unknown device sensors should use SunlitUnknownDeviceSensor class"
+    assert len(unknown_class_sensors) == len(unknown_sensors), (
+        f"All unknown device sensors should use SunlitUnknownDeviceSensor class"
+    )
 
     # Verify it's the status sensor
     status_sensor = unknown_sensors[0]
@@ -1337,20 +1422,20 @@ async def test_device_type_sensor_mapping(
     enable_custom_integrations,
 ):
     """Test the create_device_sensor factory function with different device types."""
-    from custom_components.sunlit.sensor import create_device_sensor
-    from custom_components.sunlit.entities.meter_sensor import SunlitMeterSensor
-    from custom_components.sunlit.entities.inverter_sensor import SunlitInverterSensor
+    from custom_components.sunlit.const import (
+        DEVICE_TYPE_BATTERY,
+        DEVICE_TYPE_INVERTER,
+        DEVICE_TYPE_INVERTER_SOLAR,
+        DEVICE_TYPE_METER,
+        DEVICE_TYPE_METER_PRO,
+    )
     from custom_components.sunlit.entities.battery_sensor import SunlitBatterySensor
+    from custom_components.sunlit.entities.inverter_sensor import SunlitInverterSensor
+    from custom_components.sunlit.entities.meter_sensor import SunlitMeterSensor
     from custom_components.sunlit.entities.unknown_device_sensor import (
         SunlitUnknownDeviceSensor,
     )
-    from custom_components.sunlit.const import (
-        DEVICE_TYPE_METER,
-        DEVICE_TYPE_METER_PRO,
-        DEVICE_TYPE_INVERTER,
-        DEVICE_TYPE_INVERTER_SOLAR,
-        DEVICE_TYPE_BATTERY,
-    )
+    from custom_components.sunlit.sensor import create_device_sensor
 
     # Test data for sensor creation
     test_kwargs = {
@@ -1365,36 +1450,36 @@ async def test_device_type_sensor_mapping(
 
     # Test meter device types
     meter_sensor = create_device_sensor(DEVICE_TYPE_METER, **test_kwargs)
-    assert isinstance(
-        meter_sensor, SunlitMeterSensor
-    ), f"Expected SunlitMeterSensor, got {type(meter_sensor)}"
+    assert isinstance(meter_sensor, SunlitMeterSensor), (
+        f"Expected SunlitMeterSensor, got {type(meter_sensor)}"
+    )
 
     meter_pro_sensor = create_device_sensor(DEVICE_TYPE_METER_PRO, **test_kwargs)
-    assert isinstance(
-        meter_pro_sensor, SunlitMeterSensor
-    ), f"Expected SunlitMeterSensor, got {type(meter_pro_sensor)}"
+    assert isinstance(meter_pro_sensor, SunlitMeterSensor), (
+        f"Expected SunlitMeterSensor, got {type(meter_pro_sensor)}"
+    )
 
     # Test inverter device types
     inverter_sensor = create_device_sensor(DEVICE_TYPE_INVERTER, **test_kwargs)
-    assert isinstance(
-        inverter_sensor, SunlitInverterSensor
-    ), f"Expected SunlitInverterSensor, got {type(inverter_sensor)}"
+    assert isinstance(inverter_sensor, SunlitInverterSensor), (
+        f"Expected SunlitInverterSensor, got {type(inverter_sensor)}"
+    )
 
     inverter_solar_sensor = create_device_sensor(
         DEVICE_TYPE_INVERTER_SOLAR, **test_kwargs
     )
-    assert isinstance(
-        inverter_solar_sensor, SunlitInverterSensor
-    ), f"Expected SunlitInverterSensor, got {type(inverter_solar_sensor)}"
+    assert isinstance(inverter_solar_sensor, SunlitInverterSensor), (
+        f"Expected SunlitInverterSensor, got {type(inverter_solar_sensor)}"
+    )
 
     # Test battery device type
     battery_sensor = create_device_sensor(DEVICE_TYPE_BATTERY, **test_kwargs)
-    assert isinstance(
-        battery_sensor, SunlitBatterySensor
-    ), f"Expected SunlitBatterySensor, got {type(battery_sensor)}"
+    assert isinstance(battery_sensor, SunlitBatterySensor), (
+        f"Expected SunlitBatterySensor, got {type(battery_sensor)}"
+    )
 
     # Test unknown device type (fallback)
     unknown_sensor = create_device_sensor("UNKNOWN_TYPE", **test_kwargs)
-    assert isinstance(
-        unknown_sensor, SunlitUnknownDeviceSensor
-    ), f"Expected SunlitUnknownDeviceSensor, got {type(unknown_sensor)}"
+    assert isinstance(unknown_sensor, SunlitUnknownDeviceSensor), (
+        f"Expected SunlitUnknownDeviceSensor, got {type(unknown_sensor)}"
+    )


### PR DESCRIPTION
Validates every sensor entity against the [HA sensor entity docs](https://developers.home-assistant.io/docs/core/entity/sensor/) and HA's own `DEVICE_CLASS_UNITS` / `DEVICE_CLASS_STATE_CLASSES` tables.

## Audit result
**No HA validation violations** before or after — every non-None `(device_class, state_class, unit)` triple is valid (`None` state_class is permitted, it just forgoes statistics). The gaps were missed statistics opt-ins + two semantic mis-classifications.

## Changes
- **Long-term statistics:** add `state_class=MEASUREMENT` to metered/fluctuating sensors that lacked it — battery SOC, MPPT voltage/current, time-remaining (DURATION), and `rated_power` / `max_output_power`. They now record min/mean/max.
- **BATTERY only when metered:** `SensorDeviceClass.BATTERY` limited to fluctuating SOC (`battery_level`, `batterySoc`, `battery{N}Soc`, `average_battery_level`). SOC **limits** (`hw_/battery_/strategy_/current_soc_min|max`) are config thresholds → no device class.
- **Capacity is a spec, not energy:** `battery_capacity` / module `capacity` drop the `ENERGY` device class and become `entity_category=diagnostic` (kWh unit kept).
- **ENUM where bounded:** `electricity_price_tag` (`VERY_CHEAP…VERY_EXPENSIVE`) and `*_device_status` (`Online/Offline/NotExist`) → `SensorDeviceClass.ENUM` + `options`. Strategy/battery-status stay free-text (the API returns `SELF_CONSUMPTION`, absent from openapi's strategy enum — ENUM would emit "state not in options" warnings).
- **Display precision:** `suggested_display_precision` for numeric sensors.
- **DRY:** all description metadata flows through `helpers.build_sensor_description()`.

## Tests
- `test_sensor_helpers.py`: reclassification (battery vs SOC-limits, capacity-not-energy, rated/max power MEASUREMENT, price_tag/device_status ENUM + options, precision table).
- `test_sensor_platform.py`: updated battery device/module + family creation assertions.

233 tests pass; coverage 75%; ruff/isort clean.

Deferred (noted in the audit): aligning `total`-without-`last_reset` on daily-reset energy sensors.