### PR TITLE
fix(sensors): correct state class for daily-resetting counters

### DIFF
--- a/custom_components/sunlit/entities/device_sensor_base.py
+++ b/custom_components/sunlit/entities/device_sensor_base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
@@ -11,9 +12,11 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
+from homeassistant.util import dt as dt_util
 
 from ..const import DOMAIN
 from .base import normalize_device_type
+from .helpers import is_daily_reset_total
 
 
 class SunlitDeviceSensorBase(CoordinatorEntity, SensorEntity, ABC):
@@ -65,6 +68,13 @@ class SunlitDeviceSensorBase(CoordinatorEntity, SensorEntity, ABC):
             return self.coordinator.data["devices"][self._device_id].get(
                 self.entity_description.key
             )
+        return None
+
+    @property
+    def last_reset(self) -> datetime | None:
+        """Local midnight for daily-resetting TOTAL sensors (e.g. daily_earnings)."""
+        if is_daily_reset_total(self.entity_description.key):
+            return dt_util.start_of_local_day()
         return None
 
     def _get_native_value(self) -> Any:

--- a/custom_components/sunlit/entities/family_sensor.py
+++ b/custom_components/sunlit/entities/family_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
+from homeassistant.util import dt as dt_util
 
 from ..const import (
     DOMAIN,
@@ -21,6 +22,7 @@ from ..const import (
     SENSOR_GROUP_STRATEGY,
     SENSOR_GROUPS,
 )
+from .helpers import is_daily_reset_total
 
 
 class SunlitFamilySensor(CoordinatorEntity, SensorEntity):
@@ -64,6 +66,13 @@ class SunlitFamilySensor(CoordinatorEntity, SensorEntity):
             return EntityCategory.DIAGNOSTIC
 
         # Overview, energy, and financial sensors are primary (no category)
+        return None
+
+    @property
+    def last_reset(self) -> datetime | None:
+        """Local midnight for daily-resetting TOTAL sensors (daily_earnings)."""
+        if is_daily_reset_total(self.entity_description.key):
+            return dt_util.start_of_local_day()
         return None
 
     @property

--- a/custom_components/sunlit/entities/helpers.py
+++ b/custom_components/sunlit/entities/helpers.py
@@ -113,33 +113,22 @@ def get_state_class_for_sensor(key: str) -> SensorStateClass | None:
     # Stored energy fluctuates (rises and falls) -> MEASUREMENT, never TOTAL*.
     if "storedenergy" in key.lower().replace("_", ""):
         return SensorStateClass.MEASUREMENT
-    # Lifetime cumulative energy sensors (never reset)
-    if (
-        key == "total_yield"
-        or key == "lifetime_yield"
-        or "mpptenergy" in key.lower().replace("_", "").replace(" ", "")
-        or key == "total_solar_energy"
-        or key == "total_grid_export_energy"
+    # Monetary totals must use TOTAL — MONETARY forbids TOTAL_INCREASING. The
+    # daily-resetting one (daily_earnings) carries a last_reset (see the entity's
+    # last_reset property) so the midnight reset is handled correctly.
+    if key in ("lifetime_earnings", "daily_earnings"):
+        return SensorStateClass.TOTAL
+    # Energy: lifetime totals AND daily counters are modelled as TOTAL_INCREASING.
+    # For the daily counters, TOTAL_INCREASING auto-detects the midnight reset
+    # (the value drops to ~0), so no last_reset attribute is needed and the
+    # long-term statistics stay correct across the reset.
+    if "energy" in key.lower() or key in (
+        "total_yield",
+        "lifetime_yield",
+        "daily_yield",
+        "total_power_generation",
     ):
         return SensorStateClass.TOTAL_INCREASING
-    # TOTAL state class: daily counters that reset at midnight, plus
-    # lifetime_earnings (cumulative monetary value, TOTAL per HA convention).
-    # total_power_generation is actually today's daily generation.
-    if key == "lifetime_earnings" or (
-        key == "total_power_generation"
-        or key == "daily_grid_export_energy"
-        or key == "daily_yield"
-        or key == "daily_earnings"
-    ):
-        return SensorStateClass.TOTAL
-    # Energy sensors need special handling
-    if "energy" in key.lower():
-        if "total" in key.lower():
-            return SensorStateClass.TOTAL_INCREASING
-        elif "daily" in key.lower():
-            return SensorStateClass.TOTAL
-        else:
-            return SensorStateClass.TOTAL_INCREASING
     # Measurement-type device classes opt into long-term statistics. This covers
     # power (incl. rated_power / max_output_power), voltage, current, metered
     # battery SOC, time-remaining (duration) and stored energy.
@@ -358,6 +347,19 @@ def get_icon_for_sensor(key: str, device_type: str = None) -> str | None:
     elif key == "currency":
         return "mdi:currency-eur"
     return None
+
+
+def is_daily_reset_total(key: str) -> bool:
+    """True for TOTAL sensors that reset at local midnight (need last_reset).
+
+    Energy day-counters use TOTAL_INCREASING (auto reset detection); this is for
+    the monetary day-counter (daily_earnings), where MONETARY forbids
+    TOTAL_INCREASING so a last_reset must be supplied instead.
+    """
+    return (
+        "daily" in key.lower()
+        and get_state_class_for_sensor(key) == SensorStateClass.TOTAL
+    )
 
 
 def get_options_for_sensor(key: str) -> list[str] | None:

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -186,12 +186,23 @@ class TestStateClassForSensor:
     """Test get_state_class_for_sensor function."""
 
     def test_total_increasing_sensors(self):
-        """Test sensors with total_increasing state class."""
+        """Energy counters use TOTAL_INCREASING — incl. daily ones.
+
+        Daily energy counters reset at midnight; TOTAL_INCREASING auto-detects
+        the reset (value drops to ~0), so no last_reset attribute is needed and
+        the long-term statistics stay correct across the reset.
+        """
         total_increasing = [
             "total_buy_energy",
             "total_ret_energy",
             "total_solar_energy",
             "total_grid_export_energy",
+            # daily energy counters (previously TOTAL without last_reset)
+            "daily_buy_energy",
+            "daily_ret_energy",
+            "daily_grid_export_energy",
+            "daily_yield",
+            "total_power_generation",  # daily generation despite the name
         ]
         for sensor in total_increasing:
             assert (
@@ -199,14 +210,10 @@ class TestStateClassForSensor:
             ), f"Failed for {sensor}"
 
     def test_total_sensors(self):
-        """Test sensors with total state class (daily counters)."""
+        """Only monetary totals use TOTAL (MONETARY forbids TOTAL_INCREASING)."""
         total_sensors = [
-            "daily_buy_energy",
-            "daily_ret_energy",
-            "daily_grid_export_energy",
-            "daily_yield",
-            "daily_earnings",
-            "total_power_generation",  # Despite the name, this is daily data (resets at midnight)
+            "daily_earnings",  # resets daily -> carries a last_reset (see entity)
+            "lifetime_earnings",
         ]
         for sensor in total_sensors:
             assert get_state_class_for_sensor(sensor) == SensorStateClass.TOTAL, (
@@ -453,6 +460,16 @@ class TestSensorMetadataExtras:
         assert get_options_for_sensor(key) == ["Online", "Offline", "NotExist"]
         assert get_unit_for_sensor(key) is None
         assert get_state_class_for_sensor(key) is None
+
+    def test_is_daily_reset_total(self):
+        """Only the daily MONETARY counter needs a last_reset (TOTAL + resets)."""
+        from custom_components.sunlit.entities.helpers import is_daily_reset_total
+
+        assert is_daily_reset_total("daily_earnings") is True
+        assert is_daily_reset_total("lifetime_earnings") is False  # never resets
+        # Daily ENERGY counters are TOTAL_INCREASING, not TOTAL -> no last_reset.
+        assert is_daily_reset_total("daily_yield") is False
+        assert is_daily_reset_total("daily_grid_export_energy") is False
 
     @pytest.mark.parametrize(
         ("key", "precision"),

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -208,6 +208,34 @@ async def test_family_sensor_creation(
         assert battery_sensor.entity_description.native_unit_of_measurement == "%"
 
 
+def test_daily_earnings_exposes_last_reset():
+    """daily_earnings (MONETARY TOTAL) carries a local-midnight last_reset."""
+    from homeassistant.util import dt as dt_util
+
+    from custom_components.sunlit.entities.family_sensor import SunlitFamilySensor
+    from custom_components.sunlit.entities.helpers import build_sensor_description
+
+    coordinator = MagicMock()
+    earnings = SunlitFamilySensor(
+        coordinator,
+        build_sensor_description("daily_earnings", "Daily Earnings"),
+        "entry",
+        "34038",
+        "Garage",
+    )
+    daily_yield = SunlitFamilySensor(
+        coordinator,
+        build_sensor_description("daily_yield", "Daily Yield"),
+        "entry",
+        "34038",
+        "Garage",
+    )
+
+    assert earnings.last_reset == dt_util.start_of_local_day()
+    # Energy day-counters use TOTAL_INCREASING -> no last_reset.
+    assert daily_yield.last_reset is None
+
+
 async def test_device_sensor_creation(
     hass: HomeAssistant,
     enable_custom_integrations,
@@ -244,15 +272,12 @@ async def test_device_sensor_creation(
                 assert (
                     sensor.entity_description.device_class == SensorDeviceClass.ENERGY
                 )
-                if "daily" in key:
-                    assert (
-                        sensor.entity_description.state_class == SensorStateClass.TOTAL
-                    )
-                elif "total" in key:
-                    assert (
-                        sensor.entity_description.state_class
-                        == SensorStateClass.TOTAL_INCREASING
-                    )
+                # Energy counters (daily and total) use TOTAL_INCREASING; daily
+                # ones rely on auto reset detection at midnight.
+                assert (
+                    sensor.entity_description.state_class
+                    == SensorStateClass.TOTAL_INCREASING
+                )
             elif "power" in key:
                 assert sensor.entity_description.device_class == SensorDeviceClass.POWER
                 assert (
@@ -474,7 +499,7 @@ async def test_meter_device_sensor_creation(
             assert_sensors(sensors)
             .for_device("meter_001")
             .where_key_matches(lambda k: "daily" in k and "energy" in k)
-            .has_state_class(SensorStateClass.TOTAL)
+            .has_state_class(SensorStateClass.TOTAL_INCREASING)
         )
 
         (
@@ -1103,14 +1128,15 @@ async def test_inverter_device_sensor_creation(
             )
         )
 
-        # total_power_generation is daily data (resets at midnight)
+        # total_power_generation is daily data (resets at midnight) -> the
+        # TOTAL_INCREASING reset is auto-detected, so no last_reset is required.
         (
             assert_sensors(sensors)
             .for_device("inverter_001")
             .where_key("total_power_generation")
             .matches_pattern(
                 device_class=SensorDeviceClass.ENERGY,
-                state_class=SensorStateClass.TOTAL,
+                state_class=SensorStateClass.TOTAL_INCREASING,
                 unit=UnitOfEnergy.KILO_WATT_HOUR,
             )
         )


### PR DESCRIPTION
Completes the item deferred from #194.

## Problem
Daily-resetting counters used `state_class=TOTAL` **without** a `last_reset`. At midnight the value drops to ~0, which the recorder reads as a negative delta — corrupting the long-term statistics for those sensors.

## Fix (per HA's `DEVICE_CLASS_STATE_CLASSES`: ENERGY allows total/total_increasing, MONETARY allows total only)
- **Daily ENERGY counters** → `TOTAL_INCREASING`: `daily_yield`, `daily_buy_energy`, `daily_ret_energy`, `daily_grid_export_energy`, and `total_power_generation` (daily despite the name). `TOTAL_INCREASING` auto-detects the midnight reset, so no `last_reset` is needed and stats stay correct across it.
- **`daily_earnings`** is `MONETARY` (can't be `TOTAL_INCREASING`), so it keeps `TOTAL` but now exposes a **`last_reset` at local midnight** via the entity's `last_reset` property (added to both `SunlitFamilySensor` and `SunlitDeviceSensorBase`, since it appears as a family and an inverter sensor).

`lifetime_earnings` stays `TOTAL` with no `last_reset` (it never resets).

## Tests
- `test_sensor_helpers.py`: daily energy counters now `TOTAL_INCREASING`; only monetary stays `TOTAL`; `is_daily_reset_total()` helper.
- `test_sensor_platform.py`: meter/inverter daily-energy assertions updated to `TOTAL_INCREASING`; new test that `daily_earnings` exposes a local-midnight `last_reset` while `daily_yield` does not.

235 tests pass; coverage 75%; ruff/isort clean.