### PR TITLE
fix(binary_sensor): drop BATTERY device class from battery_full

### DIFF
--- a/custom_components/sunlit/binary_sensor.py
+++ b/custom_components/sunlit/binary_sensor.py
@@ -28,7 +28,10 @@ FAMILY_BINARY_SENSORS = {
     },
     "battery_full": {
         "name": "Battery Full",
-        "device_class": BinarySensorDeviceClass.BATTERY,
+        # Not BinarySensorDeviceClass.BATTERY: that class means "low battery"
+        # (on=Low, off=Normal), which would invert and mislabel this "is full"
+        # flag. Leave unclassified so it shows a plain On/Off state.
+        "device_class": None,
         "icon": "mdi:battery-check",
     },
     # New binary sensors from space/index endpoint


### PR DESCRIPTION
## What

The `battery_full` family binary sensor declared `device_class: BinarySensorDeviceClass.BATTERY`. In Home Assistant that device class denotes a **low-battery** indicator:

- `on` → "Low"
- `off` → "Normal"

Applied to an *"is full"* flag, this:

1. **Inverts the semantics** — `batteryFull = true` makes the entity `on`, which the BATTERY device class presents as "Low".
2. **Renders it as a battery entity** in the UI (observed in a live HA instance) instead of a plain On/Off flag.

## Change

Set `device_class = None` so the sensor shows a straightforward On/Off state. The `mdi:battery-check` icon is retained, so it still reads clearly as a "battery full" indicator.

## Notes

- The state value was always correct (`bool(batteryFull)`); only the device-class presentation/semantics were wrong.
- After upgrading, reload the integration / restart HA for the device class to drop. If a device class was ever set manually on the entity via the UI, that registry override persists and must be cleared separately.

## Testing

- `pytest tests/test_family_coordinator.py tests/test_sensor_helpers.py` → 70 passed
- `ruff check` / `ruff format --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the battery_full sensor configuration to display and behave correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/ha-sunlit/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->