### PR TITLE
feat: add tariff strategy switch via cloud API (closes #174)

### DIFF
--- a/custom_components/sunlit/__init__.py
+++ b/custom_components/sunlit/__init__.py
@@ -37,6 +37,8 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.SWITCH,
+    Platform.SELECT,
+    Platform.NUMBER,
 ]
 
 

--- a/custom_components/sunlit/api_client.py
+++ b/custom_components/sunlit/api_client.py
@@ -734,9 +734,7 @@ class SunlitApiClient:
             low_price_strategy,
             high_price_strategy,
         )
-        return await self._make_request(
-            "POST", API_TARIFF_STRATEGY_ADD, json=payload
-        )
+        return await self._make_request("POST", API_TARIFF_STRATEGY_ADD, json=payload)
 
     async def fetch_tariff_index(self, space_id: str | int) -> dict[str, Any]:
         """Fetch dynamic electricity tariff/pricing for a space.

--- a/custom_components/sunlit/api_client.py
+++ b/custom_components/sunlit/api_client.py
@@ -26,6 +26,7 @@ from .const import (
     API_SPACE_STRATEGY_HISTORY,
     API_STRATEGY_DEVICE_STATUS,
     API_TARIFF_INDEX,
+    API_TARIFF_STRATEGY_ADD,
     API_USER_LOGIN,
 )
 
@@ -688,6 +689,53 @@ class SunlitApiClient:
         _LOGGER.debug("Setting battery %s local mode to %s", device_sn, enable)
         return await self._make_request(
             "POST", API_BATTERY_LOCAL_MODE_CONFIG, json=payload
+        )
+
+    async def set_tariff_strategy(
+        self,
+        family_id: str | int,
+        low_price_strategy: dict[str, Any],
+        high_price_strategy: dict[str, Any],
+        enable_switch_notice: bool = True,
+    ) -> dict[str, Any]:
+        """Add or update the tariff-based battery strategy for a family.
+
+        POSTs to /v1.6/tariffStrategy/add. Configures the battery's behaviour
+        for low- and high-price tariff windows in a single call. The endpoint
+        is all-or-nothing: callers must always supply both low and high blocks.
+
+        Args:
+            family_id: The family/space ID
+            low_price_strategy: Dict with keys ``strategy``, ``socMin``,
+                ``socMax`` and optional ``defaultExpectInverterOutput``
+            high_price_strategy: Dict with keys ``strategy``, ``socMin``,
+                ``socMax`` and optional ``smartStrategyMode``,
+                ``smartStrategyFullMode``
+            enable_switch_notice: Send a push notification when the strategy
+                switches between price bands
+
+        Returns:
+            The raw API envelope (``content`` is null on success)
+
+        Raises:
+            SunlitAuthError: Authentication failed
+            SunlitConnectionError: Connection failed
+            SunlitApiError: API returned an error
+        """
+        payload = {
+            "familyId": int(family_id),
+            "lowPriceStrategy": low_price_strategy,
+            "highPriceStrategy": high_price_strategy,
+            "enableSwitchNotice": enable_switch_notice,
+        }
+        _LOGGER.debug(
+            "Setting tariff strategy for family %s: low=%s high=%s",
+            family_id,
+            low_price_strategy,
+            high_price_strategy,
+        )
+        return await self._make_request(
+            "POST", API_TARIFF_STRATEGY_ADD, json=payload
         )
 
     async def fetch_tariff_index(self, space_id: str | int) -> dict[str, Any]:

--- a/custom_components/sunlit/api_client.py
+++ b/custom_components/sunlit/api_client.py
@@ -25,6 +25,7 @@ from .const import (
     API_SPACE_STATISTICS_STATIC,
     API_SPACE_STRATEGY_HISTORY,
     API_STRATEGY_DEVICE_STATUS,
+    API_STRATEGY_SETTING_DETAIL,
     API_TARIFF_INDEX,
     API_TARIFF_STRATEGY_ADD,
     API_USER_LOGIN,
@@ -735,6 +736,55 @@ class SunlitApiClient:
             high_price_strategy,
         )
         return await self._make_request("POST", API_TARIFF_STRATEGY_ADD, json=payload)
+
+    async def fetch_tariff_setup(self, family_id: str | int) -> dict[str, Any] | None:
+        """Read the cloud's authoritative tariff-strategy setup for a family.
+
+        POSTs to /v1.8/strategy/setting/detail with strategyType=TariffStrategy.
+        The cloud returns the currently-active low- and high-price strategy
+        blocks — the same shape we send to /v1.6/tariffStrategy/add.
+
+        This is the read side that complements ``set_tariff_strategy`` and
+        lets the coordinator reconcile its in-memory cache against
+        out-of-band edits made via the SunEnergyXT app.
+
+        Args:
+            family_id: The family/space ID
+
+        Returns:
+            A ``{"low": {...}, "high": {...}, "enableSwitchNotice": bool}``
+            dict ready to feed into the coordinator's
+            ``update_tariff_setup_field`` machinery, or ``None`` if the cloud
+            says no tariff strategy is currently configured (``enabled: false``
+            or ``content: null``).
+
+        Raises:
+            SunlitAuthError: Authentication failed
+            SunlitConnectionError: Connection failed
+            SunlitApiError: API returned an error
+        """
+        payload = {
+            "spaceId": int(family_id),
+            "primarySpaceId": int(family_id),
+            "strategyType": "TariffStrategy",
+        }
+        _LOGGER.debug("Fetching tariff setup for family %s", family_id)
+        envelope = await self._make_request(
+            "POST", API_STRATEGY_SETTING_DETAIL, json=payload
+        )
+        content = (envelope or {}).get("content")
+        if not content or not content.get("enabled"):
+            return None
+        tariff = content.get("tariffStrategy") or {}
+        low = tariff.get("lowPriceStrategy")
+        high = tariff.get("highPriceStrategy")
+        if not low or not high:
+            return None
+        return {
+            "low": low,
+            "high": high,
+            "enableSwitchNotice": bool(tariff.get("enableSwitchNotice", True)),
+        }
 
     async def fetch_tariff_index(self, space_id: str | int) -> dict[str, Any]:
         """Fetch dynamic electricity tariff/pricing for a space.

--- a/custom_components/sunlit/const.py
+++ b/custom_components/sunlit/const.py
@@ -36,6 +36,7 @@ API_BATTERY_LOCAL_MODE_CONFIG = "/v1.7/battery/updateLocalModeConfig"
 API_STRATEGY_DEVICE_STATUS = "/v1.7/strategy/device/status"
 API_TARIFF_INDEX = "/v1.6/tariff/index"
 API_TARIFF_STRATEGY_ADD = "/v1.6/tariffStrategy/add"
+API_STRATEGY_SETTING_DETAIL = "/v1.8/strategy/setting/detail"
 API_SPACE_STATISTICS_DYNAMIC_ENERGY = "/v1.1/space/statistics/dynamic/energy"
 API_NOTIFICATION_LIST = "/v1.5/notification/list"
 

--- a/custom_components/sunlit/const.py
+++ b/custom_components/sunlit/const.py
@@ -35,6 +35,7 @@ API_CHARGING_BOX_CHECK_STRATEGY = "/v1.6/chargingBox/checkSpaceStrategy"
 API_BATTERY_LOCAL_MODE_CONFIG = "/v1.7/battery/updateLocalModeConfig"
 API_STRATEGY_DEVICE_STATUS = "/v1.7/strategy/device/status"
 API_TARIFF_INDEX = "/v1.6/tariff/index"
+API_TARIFF_STRATEGY_ADD = "/v1.6/tariffStrategy/add"
 API_SPACE_STATISTICS_DYNAMIC_ENERGY = "/v1.1/space/statistics/dynamic/energy"
 API_NOTIFICATION_LIST = "/v1.5/notification/list"
 
@@ -74,6 +75,16 @@ DEFAULT_OPTIONS = {
     OPT_SOC_CHANGE_THRESHOLD: DEFAULT_SOC_CHANGE_THRESHOLD,
     OPT_MIN_EVENT_INTERVAL: DEFAULT_MIN_EVENT_INTERVAL,
 }
+
+# Tariff strategy options accepted by /v1.6/tariffStrategy/add
+TARIFF_STRATEGY_OPTIONS = ["EnergyStorageOnly", "SmartStrategy", "Manual"]
+DEFAULT_LOW_PRICE_STRATEGY = "EnergyStorageOnly"
+DEFAULT_HIGH_PRICE_STRATEGY = "SmartStrategy"
+DEFAULT_LOW_PRICE_SOC_MIN = 1
+DEFAULT_LOW_PRICE_SOC_MAX = 100
+DEFAULT_HIGH_PRICE_SOC_MIN = 10
+DEFAULT_HIGH_PRICE_SOC_MAX = 100
+DEFAULT_LOW_PRICE_INVERTER_OUTPUT = 800
 
 # Device Types
 # Meters

--- a/custom_components/sunlit/coordinators/strategy.py
+++ b/custom_components/sunlit/coordinators/strategy.py
@@ -102,8 +102,58 @@ class SunlitStrategyHistoryCoordinator(DataUpdateCoordinator):
         )
         await self.async_request_refresh()
 
+    async def _async_reconcile_tariff_setup_from_cloud(self) -> None:
+        """Read the cloud's authoritative tariff setup and overwrite the cache.
+
+        Out-of-band edits via the SunEnergyXT app would otherwise be silently
+        overwritten by the next entity push, because the cache only knew what
+        HA itself sent. After this reconcile the cache mirrors the cloud's
+        current view, so a subsequent partial-field push carries the cloud's
+        other fields back unchanged.
+
+        Failures are logged at debug level and do not abort the regular
+        history fetch — the cache simply stays on whatever it had before
+        (defaults or last-known).
+        """
+        try:
+            cloud = await self.api_client.fetch_tariff_setup(self.family_id)
+        except SunlitApiError as err:
+            _LOGGER.debug("Tariff readback failed for %s: %s", self.family_name, err)
+            return
+
+        # Defensive: only act on a real dict. Anything else (None, MagicMock
+        # leaking through tests, an upstream change in fetch_tariff_setup)
+        # leaves the cache untouched.
+        if not isinstance(cloud, dict):
+            _LOGGER.debug(
+                "No active tariff strategy on cloud for %s; cache untouched",
+                self.family_name,
+            )
+            return
+
+        low_cloud = cloud.get("low")
+        high_cloud = cloud.get("high")
+        if not isinstance(low_cloud, dict) or not isinstance(high_cloud, dict):
+            return
+
+        # Reconcile field by field, only overwriting fields we already know
+        # about. Unknown fields the cloud might add later are ignored — they
+        # would round-trip via the all-or-nothing push anyway.
+        for band, cloud_block in (("low", low_cloud), ("high", high_cloud)):
+            for field in list(self._tariff_setup[band].keys()):
+                if field in cloud_block and cloud_block[field] is not None:
+                    self._tariff_setup[band][field] = cloud_block[field]
+
     async def _async_update_data(self) -> dict[str, Any]:
-        """Fetch strategy history data from REST API."""
+        """Fetch strategy history data from REST API.
+
+        Also reconciles the cached tariff-strategy setup against the cloud's
+        authoritative view, so out-of-band edits in the SunEnergyXT app are
+        not overwritten by the next entity-driven push.
+        """
+        # Reconcile the cache before returning data — runs once per interval.
+        await self._async_reconcile_tariff_setup_from_cloud()
+
         try:
             strategy_data: dict[str, Any] = {}
 

--- a/custom_components/sunlit/coordinators/strategy.py
+++ b/custom_components/sunlit/coordinators/strategy.py
@@ -85,6 +85,10 @@ class SunlitStrategyHistoryCoordinator(DataUpdateCoordinator):
         """
         if band not in self._tariff_setup:
             raise ValueError(f"Unknown tariff band: {band}")
+        if field not in self._tariff_setup[band]:
+            raise ValueError(
+                f"Unknown field '{field}' for tariff band '{band}'"
+            )
         self._tariff_setup[band][field] = value
 
     async def async_push_tariff_setup(

--- a/custom_components/sunlit/coordinators/strategy.py
+++ b/custom_components/sunlit/coordinators/strategy.py
@@ -10,12 +10,27 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from ..api_client import SunlitApiClient
+from ..const import (
+    DEFAULT_HIGH_PRICE_SOC_MAX,
+    DEFAULT_HIGH_PRICE_SOC_MIN,
+    DEFAULT_HIGH_PRICE_STRATEGY,
+    DEFAULT_LOW_PRICE_INVERTER_OUTPUT,
+    DEFAULT_LOW_PRICE_SOC_MAX,
+    DEFAULT_LOW_PRICE_SOC_MIN,
+    DEFAULT_LOW_PRICE_STRATEGY,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class SunlitStrategyHistoryCoordinator(DataUpdateCoordinator):
-    """Coordinator for strategy history data."""
+    """Coordinator for strategy history data and tariff-strategy setup cache.
+
+    The /v1.6/tariffStrategy/add endpoint is all-or-nothing: every write must
+    carry the full low+high blocks. This coordinator owns the in-memory cache
+    of the last sent values so that individual select/number entities can
+    mutate one field at a time and the coordinator submits the bundle.
+    """
 
     def __init__(
         self,
@@ -29,12 +44,60 @@ class SunlitStrategyHistoryCoordinator(DataUpdateCoordinator):
         self.family_id = family_id
         self.family_name = family_name
 
+        # Cached tariff-strategy setup. Mutated by entity setters and read by
+        # set_tariff_strategy(). Initialised with sensible defaults; entities
+        # may overwrite via restored state on startup.
+        self._tariff_setup: dict[str, dict[str, Any]] = {
+            "low": {
+                "strategy": DEFAULT_LOW_PRICE_STRATEGY,
+                "socMin": DEFAULT_LOW_PRICE_SOC_MIN,
+                "socMax": DEFAULT_LOW_PRICE_SOC_MAX,
+                "defaultExpectInverterOutput": DEFAULT_LOW_PRICE_INVERTER_OUTPUT,
+            },
+            "high": {
+                "strategy": DEFAULT_HIGH_PRICE_STRATEGY,
+                "socMin": DEFAULT_HIGH_PRICE_SOC_MIN,
+                "socMax": DEFAULT_HIGH_PRICE_SOC_MAX,
+            },
+        }
+
         super().__init__(
             hass,
             _LOGGER,
             name=f"Sunlit Strategy History {family_name}",
             update_interval=timedelta(minutes=5),  # 5 minute updates
         )
+
+    @property
+    def tariff_setup(self) -> dict[str, dict[str, Any]]:
+        """Return the cached tariff-strategy setup (low/high blocks)."""
+        return self._tariff_setup
+
+    def update_tariff_setup_field(
+        self, band: str, field: str, value: Any
+    ) -> None:
+        """Update one field of the cached tariff setup before pushing.
+
+        Args:
+            band: ``low`` or ``high``
+            field: e.g. ``strategy``, ``socMin``, ``socMax``
+            value: new value
+        """
+        if band not in self._tariff_setup:
+            raise ValueError(f"Unknown tariff band: {band}")
+        self._tariff_setup[band][field] = value
+
+    async def async_push_tariff_setup(
+        self, enable_switch_notice: bool = True
+    ) -> None:
+        """Push the cached tariff setup to /v1.6/tariffStrategy/add."""
+        await self.api_client.set_tariff_strategy(
+            self.family_id,
+            low_price_strategy=self._tariff_setup["low"],
+            high_price_strategy=self._tariff_setup["high"],
+            enable_switch_notice=enable_switch_notice,
+        )
+        await self.async_request_refresh()
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch strategy history data from REST API."""

--- a/custom_components/sunlit/coordinators/strategy.py
+++ b/custom_components/sunlit/coordinators/strategy.py
@@ -9,7 +9,7 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from ..api_client import SunlitApiClient
+from ..api_client import SunlitApiClient, SunlitApiError
 from ..const import (
     DEFAULT_HIGH_PRICE_SOC_MAX,
     DEFAULT_HIGH_PRICE_SOC_MIN,
@@ -70,12 +70,15 @@ class SunlitStrategyHistoryCoordinator(DataUpdateCoordinator):
 
     @property
     def tariff_setup(self) -> dict[str, dict[str, Any]]:
-        """Return the cached tariff-strategy setup (low/high blocks)."""
-        return self._tariff_setup
+        """Return a defensive copy of the cached tariff-strategy setup.
 
-    def update_tariff_setup_field(
-        self, band: str, field: str, value: Any
-    ) -> None:
+        The copy keeps callers from mutating the cache directly — every
+        change must go through :meth:`update_tariff_setup_field` so that
+        validation runs and the readback path stays authoritative.
+        """
+        return {band: dict(fields) for band, fields in self._tariff_setup.items()}
+
+    def update_tariff_setup_field(self, band: str, field: str, value: Any) -> None:
         """Update one field of the cached tariff setup before pushing.
 
         Args:
@@ -86,14 +89,10 @@ class SunlitStrategyHistoryCoordinator(DataUpdateCoordinator):
         if band not in self._tariff_setup:
             raise ValueError(f"Unknown tariff band: {band}")
         if field not in self._tariff_setup[band]:
-            raise ValueError(
-                f"Unknown field '{field}' for tariff band '{band}'"
-            )
+            raise ValueError(f"Unknown field '{field}' for tariff band '{band}'")
         self._tariff_setup[band][field] = value
 
-    async def async_push_tariff_setup(
-        self, enable_switch_notice: bool = True
-    ) -> None:
+    async def async_push_tariff_setup(self, enable_switch_notice: bool = True) -> None:
         """Push the cached tariff setup to /v1.6/tariffStrategy/add."""
         await self.api_client.set_tariff_strategy(
             self.family_id,
@@ -106,7 +105,7 @@ class SunlitStrategyHistoryCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch strategy history data from REST API."""
         try:
-            strategy_data = {}
+            strategy_data: dict[str, Any] = {}
 
             # Fetch strategy history
             strategy_history = await self.api_client.fetch_space_strategy_history(
@@ -142,7 +141,7 @@ class SunlitStrategyHistoryCoordinator(DataUpdateCoordinator):
 
             return {"strategy": strategy_data}
 
-        except Exception as err:
+        except SunlitApiError as err:
             _LOGGER.warning(
                 "Error fetching strategy history for %s: %s", self.family_name, err
             )

--- a/custom_components/sunlit/number.py
+++ b/custom_components/sunlit/number.py
@@ -1,0 +1,161 @@
+"""Number platform for the Sunlit integration: tariff strategy SOC limits."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PERCENTAGE
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinators.strategy import SunlitStrategyHistoryCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# (band, field, friendly suffix)
+_NUMBER_FIELDS: list[tuple[str, str, str]] = [
+    ("low", "socMin", "Low Price SOC Min"),
+    ("low", "socMax", "Low Price SOC Max"),
+    ("high", "socMin", "High Price SOC Min"),
+    ("high", "socMax", "High Price SOC Max"),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the number platform."""
+    integration_data = hass.data[DOMAIN][config_entry.entry_id]
+
+    if isinstance(integration_data, dict) and "coordinators" in integration_data:
+        coordinators = integration_data["coordinators"]
+    else:
+        coordinators = integration_data
+
+    entities: list[NumberEntity] = []
+    for family_id, coordinator_set in coordinators.items():
+        if not isinstance(coordinator_set, dict):
+            continue
+        strategy_coord = coordinator_set.get("strategy")
+        if not isinstance(strategy_coord, SunlitStrategyHistoryCoordinator):
+            continue
+        for band, field, suffix in _NUMBER_FIELDS:
+            entities.append(
+                SunlitTariffSocNumber(
+                    coordinator=strategy_coord,
+                    entry_id=config_entry.entry_id,
+                    family_id=family_id,
+                    family_name=strategy_coord.family_name,
+                    band=band,
+                    field=field,
+                    name_suffix=suffix,
+                )
+            )
+
+    async_add_entities(entities, True)
+
+
+class SunlitTariffSocNumber(
+    CoordinatorEntity[SunlitStrategyHistoryCoordinator], NumberEntity, RestoreEntity
+):
+    """Number entity controlling one SOC limit field of the tariff strategy."""
+
+    _attr_has_entity_name = True
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_native_min_value = 1
+    _attr_native_max_value = 100
+    _attr_native_step = 1
+    _attr_mode = NumberMode.SLIDER
+    _attr_icon = "mdi:battery-charging"
+
+    def __init__(
+        self,
+        coordinator: SunlitStrategyHistoryCoordinator,
+        entry_id: str,
+        family_id: str,
+        family_name: str,
+        band: str,
+        field: str,
+        name_suffix: str,
+    ) -> None:
+        """Initialize the SOC number entity."""
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._family_id = family_id
+        self._family_name = family_name
+        self._band = band
+        self._field = field
+
+        slug = family_name.lower().replace(" ", "_")
+        self._attr_unique_id = (
+            f"sunlit_{slug}_{family_id}_tariff_{band}_{field}"
+        )
+        self._attr_name = name_suffix
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the cached SOC value for this field."""
+        value = self.coordinator.tariff_setup[self._band].get(self._field)
+        if value is None:
+            return None
+        return float(value)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Attach to the family device."""
+        return DeviceInfo(identifiers={(DOMAIN, f"family_{self._family_id}")})
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last value into the coordinator cache."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state and last_state.state not in (None, "unknown", "unavailable"):
+            try:
+                self.coordinator.update_tariff_setup_field(
+                    self._band, self._field, int(float(last_state.state))
+                )
+            except (TypeError, ValueError):
+                pass
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Push a new SOC limit to the API."""
+        int_value = int(value)
+        # Basic sanity: keep min < max for a band
+        other_field = "socMax" if self._field == "socMin" else "socMin"
+        other_value = self.coordinator.tariff_setup[self._band].get(other_field)
+        if other_value is not None:
+            if self._field == "socMin" and int_value >= int(other_value):
+                raise HomeAssistantError(
+                    f"{self._band}-price socMin must be < socMax ({other_value})"
+                )
+            if self._field == "socMax" and int_value <= int(other_value):
+                raise HomeAssistantError(
+                    f"{self._band}-price socMax must be > socMin ({other_value})"
+                )
+
+        self.coordinator.update_tariff_setup_field(
+            self._band, self._field, int_value
+        )
+        try:
+            await self.coordinator.async_push_tariff_setup()
+        except Exception as err:
+            raise HomeAssistantError(
+                f"Failed to set {self._band}-price {self._field}: {err}"
+            ) from err
+        self.async_write_ha_state()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose band/field for diagnostics."""
+        return {"band": self._band, "field": self._field}

--- a/custom_components/sunlit/number.py
+++ b/custom_components/sunlit/number.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from homeassistant.components.number import NumberEntity, NumberMode
@@ -15,11 +14,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .api_client import SunlitApiError
 from .const import DOMAIN
 from .coordinators.strategy import SunlitStrategyHistoryCoordinator
-
-_LOGGER = logging.getLogger(__name__)
-
 
 # (band, field, friendly suffix)
 _NUMBER_FIELDS: list[tuple[str, str, str]] = [
@@ -98,9 +95,7 @@ class SunlitTariffSocNumber(
         self._field = field
 
         slug = family_name.lower().replace(" ", "_")
-        self._attr_unique_id = (
-            f"sunlit_{slug}_{family_id}_tariff_{band}_{field}"
-        )
+        self._attr_unique_id = f"sunlit_{slug}_{family_id}_tariff_{band}_{field}"
         self._attr_name = name_suffix
 
     @property
@@ -145,12 +140,10 @@ class SunlitTariffSocNumber(
                 )
 
         previous_value = self.coordinator.tariff_setup[self._band].get(self._field)
-        self.coordinator.update_tariff_setup_field(
-            self._band, self._field, int_value
-        )
+        self.coordinator.update_tariff_setup_field(self._band, self._field, int_value)
         try:
             await self.coordinator.async_push_tariff_setup()
-        except Exception as err:
+        except SunlitApiError as err:
             self.coordinator.update_tariff_setup_field(
                 self._band, self._field, previous_value
             )

--- a/custom_components/sunlit/number.py
+++ b/custom_components/sunlit/number.py
@@ -144,12 +144,16 @@ class SunlitTariffSocNumber(
                     f"{self._band}-price socMax must be > socMin ({other_value})"
                 )
 
+        previous_value = self.coordinator.tariff_setup[self._band].get(self._field)
         self.coordinator.update_tariff_setup_field(
             self._band, self._field, int_value
         )
         try:
             await self.coordinator.async_push_tariff_setup()
         except Exception as err:
+            self.coordinator.update_tariff_setup_field(
+                self._band, self._field, previous_value
+            )
             raise HomeAssistantError(
                 f"Failed to set {self._band}-price {self._field}: {err}"
             ) from err

--- a/custom_components/sunlit/select.py
+++ b/custom_components/sunlit/select.py
@@ -1,0 +1,143 @@
+"""Select platform for the Sunlit integration: tariff strategy choice."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, TARIFF_STRATEGY_OPTIONS
+from .coordinators.strategy import SunlitStrategyHistoryCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the select platform."""
+    integration_data = hass.data[DOMAIN][config_entry.entry_id]
+
+    if isinstance(integration_data, dict) and "coordinators" in integration_data:
+        coordinators = integration_data["coordinators"]
+    else:
+        coordinators = integration_data
+
+    entities: list[SelectEntity] = []
+
+    for family_id, coordinator_set in coordinators.items():
+        if not isinstance(coordinator_set, dict):
+            continue
+        strategy_coord = coordinator_set.get("strategy")
+        if not isinstance(strategy_coord, SunlitStrategyHistoryCoordinator):
+            continue
+        entities.extend(
+            [
+                SunlitTariffStrategySelect(
+                    coordinator=strategy_coord,
+                    entry_id=config_entry.entry_id,
+                    family_id=family_id,
+                    family_name=strategy_coord.family_name,
+                    band="low",
+                ),
+                SunlitTariffStrategySelect(
+                    coordinator=strategy_coord,
+                    entry_id=config_entry.entry_id,
+                    family_id=family_id,
+                    family_name=strategy_coord.family_name,
+                    band="high",
+                ),
+            ]
+        )
+
+    async_add_entities(entities, True)
+
+
+class SunlitTariffStrategySelect(
+    CoordinatorEntity[SunlitStrategyHistoryCoordinator], SelectEntity, RestoreEntity
+):
+    """Select entity for the per-band tariff strategy.
+
+    Backs onto the coordinator's cached tariff setup. Selecting an option
+    mutates the cache for this band and pushes the full bundle to
+    /v1.6/tariffStrategy/add.
+    """
+
+    _attr_has_entity_name = True
+    _attr_options = TARIFF_STRATEGY_OPTIONS
+    _attr_icon = "mdi:battery-sync"
+
+    def __init__(
+        self,
+        coordinator: SunlitStrategyHistoryCoordinator,
+        entry_id: str,
+        family_id: str,
+        family_name: str,
+        band: str,
+    ) -> None:
+        """Initialize the strategy select."""
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._family_id = family_id
+        self._family_name = family_name
+        self._band = band  # "low" | "high"
+
+        slug = family_name.lower().replace(" ", "_")
+        self._attr_unique_id = (
+            f"sunlit_{slug}_{family_id}_tariff_strategy_{band}"
+        )
+        nice = "Low Price" if band == "low" else "High Price"
+        self._attr_name = f"{nice} Strategy"
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the cached strategy for this band."""
+        return self.coordinator.tariff_setup[self._band].get("strategy")
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Attach to the family device."""
+        return DeviceInfo(identifiers={(DOMAIN, f"family_{self._family_id}")})
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the previously selected option from state cache."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state and last_state.state in TARIFF_STRATEGY_OPTIONS:
+            self.coordinator.update_tariff_setup_field(
+                self._band, "strategy", last_state.state
+            )
+
+    async def async_select_option(self, option: str) -> None:
+        """Push the new strategy to the API."""
+        if option not in TARIFF_STRATEGY_OPTIONS:
+            raise HomeAssistantError(f"Invalid strategy option: {option}")
+        self.coordinator.update_tariff_setup_field(
+            self._band, "strategy", option
+        )
+        try:
+            await self.coordinator.async_push_tariff_setup()
+        except Exception as err:
+            raise HomeAssistantError(
+                f"Failed to set {self._band}-price strategy: {err}"
+            ) from err
+        self.async_write_ha_state()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Surface the cached low/high bundle for debugging."""
+        return {
+            "band": self._band,
+            "low_price_strategy": self.coordinator.tariff_setup["low"],
+            "high_price_strategy": self.coordinator.tariff_setup["high"],
+        }

--- a/custom_components/sunlit/select.py
+++ b/custom_components/sunlit/select.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from homeassistant.components.select import SelectEntity
@@ -14,10 +13,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .api_client import SunlitApiError
 from .const import DOMAIN, TARIFF_STRATEGY_OPTIONS
 from .coordinators.strategy import SunlitStrategyHistoryCoordinator
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -93,9 +91,7 @@ class SunlitTariffStrategySelect(
         self._band = band  # "low" | "high"
 
         slug = family_name.lower().replace(" ", "_")
-        self._attr_unique_id = (
-            f"sunlit_{slug}_{family_id}_tariff_strategy_{band}"
-        )
+        self._attr_unique_id = f"sunlit_{slug}_{family_id}_tariff_strategy_{band}"
         nice = "Low Price" if band == "low" else "High Price"
         self._attr_name = f"{nice} Strategy"
 
@@ -123,12 +119,10 @@ class SunlitTariffStrategySelect(
         if option not in TARIFF_STRATEGY_OPTIONS:
             raise HomeAssistantError(f"Invalid strategy option: {option}")
         previous_option = self.coordinator.tariff_setup[self._band].get("strategy")
-        self.coordinator.update_tariff_setup_field(
-            self._band, "strategy", option
-        )
+        self.coordinator.update_tariff_setup_field(self._band, "strategy", option)
         try:
             await self.coordinator.async_push_tariff_setup()
-        except Exception as err:
+        except SunlitApiError as err:
             self.coordinator.update_tariff_setup_field(
                 self._band, "strategy", previous_option
             )
@@ -140,8 +134,9 @@ class SunlitTariffStrategySelect(
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Surface the cached low/high bundle for debugging."""
+        setup = self.coordinator.tariff_setup
         return {
             "band": self._band,
-            "low_price_strategy": self.coordinator.tariff_setup["low"],
-            "high_price_strategy": self.coordinator.tariff_setup["high"],
+            "low_price_strategy": dict(setup["low"]),
+            "high_price_strategy": dict(setup["high"]),
         }

--- a/custom_components/sunlit/select.py
+++ b/custom_components/sunlit/select.py
@@ -122,12 +122,16 @@ class SunlitTariffStrategySelect(
         """Push the new strategy to the API."""
         if option not in TARIFF_STRATEGY_OPTIONS:
             raise HomeAssistantError(f"Invalid strategy option: {option}")
+        previous_option = self.coordinator.tariff_setup[self._band].get("strategy")
         self.coordinator.update_tariff_setup_field(
             self._band, "strategy", option
         )
         try:
             await self.coordinator.async_push_tariff_setup()
         except Exception as err:
+            self.coordinator.update_tariff_setup_field(
+                self._band, "strategy", previous_option
+            )
             raise HomeAssistantError(
                 f"Failed to set {self._band}-price strategy: {err}"
             ) from err

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1101,6 +1101,108 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /v1.8/strategy/setting/detail:
+    post:
+      tags:
+        - Strategy
+      summary: Read the active setup for a single strategy type
+      description: |
+        Returns the currently-stored configuration for one strategy type
+        (`TariffStrategy`, `SmartStrategy`, `EnergyStorageOnly`, …) on a given
+        space. The shape mirrors what `/v1.6/tariffStrategy/add` (and the
+        equivalent setters for other types) accepts on the way back in — i.e.
+        this is the **read side** of the writes performed via those endpoints.
+
+        Used by the integration's `SunlitStrategyHistoryCoordinator` to
+        reconcile its in-memory tariff-strategy cache against out-of-band
+        edits made in the SunEnergyXT app. Without this readback, an entity
+        push from HA would silently overwrite app-side changes because the
+        all-or-nothing `tariffStrategy/add` endpoint requires every field on
+        every call.
+      operationId: getStrategySettingDetail
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - spaceId
+                - primarySpaceId
+                - strategyType
+              properties:
+                spaceId:
+                  type: integer
+                  example: 40566
+                primarySpaceId:
+                  type: integer
+                  example: 40566
+                strategyType:
+                  type: string
+                  enum:
+                    - TariffStrategy
+                    - SmartStrategy
+                    - EnergyStorageOnly
+                    - AcCouple
+                    - CustomAdjustments
+                    - MultiSpaceSmartStrategy
+                    - EvStrategy
+                  example: TariffStrategy
+      responses:
+        "200":
+          description: |
+            Standard envelope. `content.enabled` is `false` when no strategy
+            of the requested type is currently active for the space.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StrategySettingDetailResponse"
+              examples:
+                tariff_active:
+                  summary: TariffStrategy currently active
+                  value:
+                    code: 0
+                    responseTime: 1780156858545
+                    message:
+                      DE: Ok
+                      EN: Ok
+                    content:
+                      strategyType: TariffStrategy
+                      spaceId: 40566
+                      enabled: true
+                      settingId: 8a010ca5-fefe-41e6-9894-9e7a85bf1b97
+                      storageStrategy: null
+                      acCouple: null
+                      tariffStrategy:
+                        enableSwitchNotice: true
+                        lowPriceStrategy:
+                          strategy: EnergyStorageOnly
+                          socMin: 1
+                          socMax: 90
+                          defaultExpectInverterOutput: 300.0
+                          smartStrategyMode: usagePriority
+                          smartStrategyFullMode: throttle
+                          smartStrategyMaxOutputPower: null
+                          smartStrategyVersion: null
+                          gridChargingEnabled: null
+                          chargingPower: null
+                          acCoupleEnabled: null
+                        highPriceStrategy:
+                          strategy: SmartStrategy
+                          socMin: 10
+                          socMax: 100
+                          defaultExpectInverterOutput: null
+                          smartStrategyMode: usagePriority
+                          smartStrategyFullMode: throttle
+                          smartStrategyMaxOutputPower: 2000.0
+                          smartStrategyVersion: V1
+                          gridChargingEnabled: null
+                          chargingPower: null
+                          acCoupleEnabled: false
+                      evStrategy: null
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
   /v1.7/strategy/device/status:
     post:
       tags:
@@ -3766,6 +3868,48 @@ components:
                   items:
                     type: object
                   example: []
+
+    StrategySettingDetailResponse:
+      allOf:
+        - $ref: "#/components/schemas/ApiResponse"
+        - type: object
+          properties:
+            content:
+              type: ["object", "null"]
+              description: |
+                The cloud-stored configuration for the requested strategy
+                type. ``null`` (or ``enabled: false``) means no strategy of
+                that type is currently active.
+              properties:
+                strategyType:
+                  type: string
+                  example: TariffStrategy
+                spaceId:
+                  type: integer
+                  example: 40566
+                enabled:
+                  type: boolean
+                  example: true
+                settingId:
+                  type: string
+                  example: 8a010ca5-fefe-41e6-9894-9e7a85bf1b97
+                storageStrategy:
+                  type: ["object", "null"]
+                  description: Populated when strategyType=SmartStrategy
+                acCouple:
+                  type: ["object", "null"]
+                tariffStrategy:
+                  type: ["object", "null"]
+                  description: Populated when strategyType=TariffStrategy
+                  properties:
+                    enableSwitchNotice:
+                      type: boolean
+                    lowPriceStrategy:
+                      $ref: "#/components/schemas/LowPriceStrategy"
+                    highPriceStrategy:
+                      $ref: "#/components/schemas/HighPriceStrategy"
+                evStrategy:
+                  type: ["object", "null"]
 
     StrategyDeviceStatusResponse:
       allOf:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -670,6 +670,14 @@ paths:
         Configure tariff-based battery charging strategies for low and high electricity prices.
         Allows setting different behaviors for when electricity prices are cheap vs expensive,
         including energy storage mode, smart strategy settings, and SOC limits.
+
+        **All-or-nothing:** every call must carry the full `lowPriceStrategy` and
+        `highPriceStrategy` blocks — there is no partial-update path.
+
+        **Server-side validation:** the cloud rejects logically invalid combinations
+        (e.g. `EnergyStorageOnly` as the high-price strategy, or `socMin >= socMax`)
+        with a HTTP 200 envelope but `code: 500003`. Clients must inspect `code`
+        before treating a 200 as success — see the rejected response example below.
       operationId: addTariffStrategy
       requestBody:
         required: true
@@ -697,11 +705,32 @@ paths:
                   example: 34038
       responses:
         "200":
-          description: Successful response
+          description: |
+            Standard envelope. Either accepted (`code: 0`) or
+            rejected by server-side validation (`code: 500003`).
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/TariffStrategyAddResponse"
+              examples:
+                accepted:
+                  summary: Accepted — strategy stored
+                  value:
+                    code: 0
+                    responseTime: 1716800000000
+                    message:
+                      DE: "Ok"
+                      EN: "Ok"
+                    content: null
+                rejected:
+                  summary: Rejected — invalid combination (e.g. EnergyStorageOnly as high-price)
+                  value:
+                    code: 500003
+                    responseTime: 1716800000000
+                    message:
+                      DE: "Der Service ist vorübergehend nicht verfügbar"
+                      EN: "Service temporarily unavailable"
+                    content: null
         "401":
           $ref: "#/components/responses/Unauthorized"
 

--- a/tests/fixtures/api/strategy_setting_detail_tariff_active.json
+++ b/tests/fixtures/api/strategy_setting_detail_tariff_active.json
@@ -1,0 +1,46 @@
+{
+  "code": 0,
+  "responseTime": 1780156858545,
+  "message": {
+    "DE": "Ok",
+    "EN": "Ok"
+  },
+  "content": {
+    "strategyType": "TariffStrategy",
+    "spaceId": 40566,
+    "enabled": true,
+    "settingId": "8a010ca5-fefe-41e6-9894-9e7a85bf1b97",
+    "storageStrategy": null,
+    "acCouple": null,
+    "tariffStrategy": {
+      "enableSwitchNotice": true,
+      "lowPriceStrategy": {
+        "strategy": "EnergyStorageOnly",
+        "socMin": 1,
+        "socMax": 90,
+        "defaultExpectInverterOutput": 300.0,
+        "smartStrategyMode": "usagePriority",
+        "smartStrategyFullMode": "throttle",
+        "smartStrategyMaxOutputPower": null,
+        "smartStrategyVersion": null,
+        "gridChargingEnabled": null,
+        "chargingPower": null,
+        "acCoupleEnabled": null
+      },
+      "highPriceStrategy": {
+        "strategy": "SmartStrategy",
+        "socMin": 10,
+        "socMax": 100,
+        "defaultExpectInverterOutput": null,
+        "smartStrategyMode": "usagePriority",
+        "smartStrategyFullMode": "throttle",
+        "smartStrategyMaxOutputPower": 2000.0,
+        "smartStrategyVersion": "V1",
+        "gridChargingEnabled": null,
+        "chargingPower": null,
+        "acCoupleEnabled": false
+      }
+    },
+    "evStrategy": null
+  }
+}

--- a/tests/fixtures/api/strategy_setting_detail_tariff_disabled.json
+++ b/tests/fixtures/api/strategy_setting_detail_tariff_disabled.json
@@ -1,0 +1,18 @@
+{
+  "code": 0,
+  "responseTime": 1780157000000,
+  "message": {
+    "DE": "Ok",
+    "EN": "Ok"
+  },
+  "content": {
+    "strategyType": "TariffStrategy",
+    "spaceId": 40566,
+    "enabled": false,
+    "settingId": null,
+    "storageStrategy": null,
+    "acCouple": null,
+    "tariffStrategy": null,
+    "evStrategy": null
+  }
+}

--- a/tests/fixtures/api/tariff_strategy_add_accepted.json
+++ b/tests/fixtures/api/tariff_strategy_add_accepted.json
@@ -1,0 +1,9 @@
+{
+  "code": 0,
+  "responseTime": 1716800000000,
+  "message": {
+    "DE": "Ok",
+    "EN": "Ok"
+  },
+  "content": null
+}

--- a/tests/fixtures/api/tariff_strategy_add_rejected_500003.json
+++ b/tests/fixtures/api/tariff_strategy_add_rejected_500003.json
@@ -1,0 +1,9 @@
+{
+  "code": 500003,
+  "responseTime": 1716800000000,
+  "message": {
+    "DE": "Der Service ist vorübergehend nicht verfügbar",
+    "EN": "Service temporarily unavailable"
+  },
+  "content": null
+}

--- a/tests/test_strategy_coordinator.py
+++ b/tests/test_strategy_coordinator.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 from homeassistant.core import HomeAssistant
 
+from custom_components.sunlit.api_client import SunlitApiError
 from custom_components.sunlit.coordinators.strategy import (
     SunlitStrategyHistoryCoordinator,
 )
@@ -84,9 +85,11 @@ async def test_strategy_coordinator_api_failure(
     hass: HomeAssistant,
     enable_custom_integrations,
 ):
-    """Test strategy coordinator handles API failures gracefully."""
+    """Test strategy coordinator handles SunlitApiError gracefully."""
     api_client = AsyncMock()
-    api_client.fetch_space_strategy_history.side_effect = Exception("API failed")
+    api_client.fetch_space_strategy_history.side_effect = SunlitApiError(
+        "API failed"
+    )
 
     coordinator = SunlitStrategyHistoryCoordinator(
         hass,

--- a/tests/test_tariff_strategy_entities.py
+++ b/tests/test_tariff_strategy_entities.py
@@ -132,6 +132,9 @@ async def test_number_socmax_must_be_above_socmin(
     with pytest.raises(HomeAssistantError, match="must be > socMin"):
         await entity.async_set_native_value(20)
 
+    # Fail-fast: must abort before any API call, same as the socMin test.
+    coord.api_client.set_tariff_strategy.assert_not_called()
+
 
 async def test_number_rolls_back_on_push_failure(
     hass: HomeAssistant, enable_custom_integrations

--- a/tests/test_tariff_strategy_entities.py
+++ b/tests/test_tariff_strategy_entities.py
@@ -1,0 +1,240 @@
+"""Tests for the tariff-strategy entities (select + number).
+
+These exercise:
+- update flow: entity → coordinator cache → push
+- rollback when the push fails (cache reverts to the previous value)
+- socMin < socMax sanity guard on the SOC number entities
+- RestoreEntity populates the coordinator cache from the last seen state
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.sunlit.api_client import SunlitApiError
+from custom_components.sunlit.coordinators.strategy import (
+    SunlitStrategyHistoryCoordinator,
+)
+from custom_components.sunlit.number import SunlitTariffSocNumber
+from custom_components.sunlit.select import SunlitTariffStrategySelect
+
+
+def _make_coord(hass: HomeAssistant) -> SunlitStrategyHistoryCoordinator:
+    api = AsyncMock()
+    api.set_tariff_strategy.return_value = {
+        "code": 0,
+        "responseTime": 1716800000000,
+        "message": {"DE": "Ok"},
+        "content": None,
+    }
+    api.fetch_space_strategy_history.return_value = {"content": []}
+    coord = SunlitStrategyHistoryCoordinator(
+        hass=hass,
+        api_client=api,
+        family_id="34038",
+        family_name="Garage",
+    )
+    # Don't schedule the periodic refresh timer during entity tests.
+    coord.async_request_refresh = AsyncMock()
+    return coord
+
+
+def _make_select(coord, band: str = "low") -> SunlitTariffStrategySelect:
+    entity = SunlitTariffStrategySelect(
+        coordinator=coord,
+        entry_id="test_entry_id",
+        family_id="34038",
+        family_name="Garage",
+        band=band,
+    )
+    entity.hass = coord.hass
+    entity.async_write_ha_state = MagicMock()
+    return entity
+
+
+def _make_number(coord, band: str, field: str) -> SunlitTariffSocNumber:
+    entity = SunlitTariffSocNumber(
+        coordinator=coord,
+        entry_id="test_entry_id",
+        family_id="34038",
+        family_name="Garage",
+        band=band,
+        field=field,
+        name_suffix=f"{band} {field}",
+    )
+    entity.hass = coord.hass
+    entity.async_write_ha_state = MagicMock()
+    return entity
+
+
+# ---------- select rollback ----------
+
+
+async def test_select_rolls_back_on_push_failure(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    coord = _make_coord(hass)
+    coord.api_client.set_tariff_strategy.side_effect = SunlitApiError(
+        "API error: Service temporarily unavailable"
+    )
+    entity = _make_select(coord, band="high")
+
+    previous = coord.tariff_setup["high"]["strategy"]
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_select_option("EnergyStorageOnly")
+
+    # Cache must have been reverted, not stuck on the rejected value.
+    assert coord.tariff_setup["high"]["strategy"] == previous
+
+
+async def test_select_invalid_option_raises_without_pushing(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    coord = _make_coord(hass)
+    entity = _make_select(coord)
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_select_option("not-a-real-strategy")
+
+    coord.api_client.set_tariff_strategy.assert_not_called()
+
+
+# ---------- number rollback + socMin < socMax ----------
+
+
+async def test_number_socmin_must_be_below_socmax(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    coord = _make_coord(hass)
+    # Force a known socMax so the assertion is deterministic.
+    coord.update_tariff_setup_field("low", "socMax", 80)
+    entity = _make_number(coord, band="low", field="socMin")
+
+    with pytest.raises(HomeAssistantError, match="must be < socMax"):
+        await entity.async_set_native_value(80)
+
+    # Nothing was pushed.
+    coord.api_client.set_tariff_strategy.assert_not_called()
+
+
+async def test_number_socmax_must_be_above_socmin(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    coord = _make_coord(hass)
+    coord.update_tariff_setup_field("low", "socMin", 20)
+    entity = _make_number(coord, band="low", field="socMax")
+
+    with pytest.raises(HomeAssistantError, match="must be > socMin"):
+        await entity.async_set_native_value(20)
+
+
+async def test_number_rolls_back_on_push_failure(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    coord = _make_coord(hass)
+    coord.update_tariff_setup_field("low", "socMin", 1)
+    coord.update_tariff_setup_field("low", "socMax", 90)
+    coord.api_client.set_tariff_strategy.side_effect = SunlitApiError(
+        "API error: Service temporarily unavailable"
+    )
+    entity = _make_number(coord, band="low", field="socMin")
+
+    previous = coord.tariff_setup["low"]["socMin"]
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_set_native_value(15)
+
+    assert coord.tariff_setup["low"]["socMin"] == previous
+
+
+async def test_number_happy_path_writes_cache(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    coord = _make_coord(hass)
+    coord.update_tariff_setup_field("low", "socMin", 1)
+    coord.update_tariff_setup_field("low", "socMax", 90)
+    entity = _make_number(coord, band="low", field="socMin")
+
+    await entity.async_set_native_value(20)
+
+    assert coord.tariff_setup["low"]["socMin"] == 20
+    coord.api_client.set_tariff_strategy.assert_called_once()
+
+
+# ---------- RestoreEntity populates cache ----------
+
+
+async def test_select_restore_writes_cache_on_added_to_hass(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    coord = _make_coord(hass)
+    entity = _make_select(coord, band="low")
+    last_state = MagicMock()
+    last_state.state = "EnergyStorageOnly"
+
+    # Skip CoordinatorEntity.async_added_to_hass() — it would attach a refresh
+    # listener and leave a lingering 5-min timer in the test loop. We only
+    # care about the restore branch here.
+    with patch.object(
+        SunlitTariffStrategySelect.__bases__[0],
+        "async_added_to_hass",
+        new=AsyncMock(),
+    ), patch.object(
+        SunlitTariffStrategySelect,
+        "async_get_last_state",
+        new=AsyncMock(return_value=last_state),
+    ):
+        await entity.async_added_to_hass()
+
+    assert coord.tariff_setup["low"]["strategy"] == "EnergyStorageOnly"
+
+
+async def test_number_restore_writes_cache_on_added_to_hass(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    coord = _make_coord(hass)
+    entity = _make_number(coord, band="high", field="socMin")
+    last_state = MagicMock()
+    last_state.state = "25"
+
+    with patch.object(
+        SunlitTariffSocNumber.__bases__[0],
+        "async_added_to_hass",
+        new=AsyncMock(),
+    ), patch.object(
+        SunlitTariffSocNumber,
+        "async_get_last_state",
+        new=AsyncMock(return_value=last_state),
+    ):
+        await entity.async_added_to_hass()
+
+    assert coord.tariff_setup["high"]["socMin"] == 25
+
+
+async def test_number_restore_ignores_unparseable_state(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    coord = _make_coord(hass)
+    original = coord.tariff_setup["high"]["socMin"]
+    entity = _make_number(coord, band="high", field="socMin")
+    last_state = MagicMock()
+    last_state.state = "not-a-number"
+
+    with patch.object(
+        SunlitTariffSocNumber.__bases__[0],
+        "async_added_to_hass",
+        new=AsyncMock(),
+    ), patch.object(
+        SunlitTariffSocNumber,
+        "async_get_last_state",
+        new=AsyncMock(return_value=last_state),
+    ):
+        await entity.async_added_to_hass()
+
+    # Stays on the default — bad state didn't poison the cache.
+    assert coord.tariff_setup["high"]["socMin"] == original

--- a/tests/test_tariff_strategy_push.py
+++ b/tests/test_tariff_strategy_push.py
@@ -1,0 +1,136 @@
+"""Tests for the tariff-strategy push path on the strategy coordinator."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.sunlit.api_client import SunlitApiError
+from custom_components.sunlit.coordinators.strategy import (
+    SunlitStrategyHistoryCoordinator,
+)
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "api"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+def _make_coordinator(
+    hass: HomeAssistant, api_client: AsyncMock
+) -> SunlitStrategyHistoryCoordinator:
+    return SunlitStrategyHistoryCoordinator(
+        hass=hass,
+        api_client=api_client,
+        family_id="34038",
+        family_name="Test Family",
+    )
+
+
+# ---------- update_tariff_setup_field validation ----------
+
+
+async def test_update_tariff_setup_field_unknown_band_raises(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    """Unknown bands must be rejected so typos don't silently grow the cache."""
+    coord = _make_coordinator(hass, AsyncMock())
+
+    with pytest.raises(ValueError, match="Unknown tariff band"):
+        coord.update_tariff_setup_field("medium", "strategy", "SmartStrategy")
+
+
+async def test_update_tariff_setup_field_unknown_field_raises(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    """Unknown fields must be rejected, not stored as a stray dict key."""
+    coord = _make_coordinator(hass, AsyncMock())
+
+    with pytest.raises(ValueError, match="Unknown field"):
+        coord.update_tariff_setup_field("low", "bogusField", 42)
+
+
+async def test_update_tariff_setup_field_writes_value(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    """Happy path: valid (band, field) writes through to the cache."""
+    coord = _make_coordinator(hass, AsyncMock())
+
+    coord.update_tariff_setup_field("low", "socMin", 5)
+
+    assert coord.tariff_setup["low"]["socMin"] == 5
+
+
+# ---------- async_push_tariff_setup behaviour ----------
+
+
+async def test_async_push_sends_full_low_and_high_blocks(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    """Push must always carry both blocks — endpoint is all-or-nothing."""
+    api = AsyncMock()
+    api.set_tariff_strategy.return_value = _load("tariff_strategy_add_accepted.json")
+    api.fetch_space_strategy_history.return_value = {"content": []}
+    coord = _make_coordinator(hass, api)
+    # Don't schedule the periodic timer in the test.
+    coord.async_request_refresh = AsyncMock()
+
+    coord.update_tariff_setup_field("low", "socMin", 5)
+    coord.update_tariff_setup_field("high", "socMax", 95)
+
+    await coord.async_push_tariff_setup()
+
+    api.set_tariff_strategy.assert_called_once()
+    kwargs = api.set_tariff_strategy.call_args.kwargs or {}
+    args = api.set_tariff_strategy.call_args.args
+    # Either positional or kwargs — pull out the two blocks robustly.
+    low = kwargs.get("low_price_strategy")
+    high = kwargs.get("high_price_strategy")
+    if low is None and len(args) >= 3:
+        low, high = args[1], args[2]
+    assert low is not None and high is not None, "both blocks must be sent"
+    assert low["socMin"] == 5
+    assert high["socMax"] == 95
+    # The block must contain *all* fields, not only the changed one.
+    assert {"strategy", "socMin", "socMax"}.issubset(low.keys())
+    assert {"strategy", "socMin", "socMax"}.issubset(high.keys())
+
+
+async def test_tariff_setup_property_returns_defensive_copy(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    """Mutating the returned dict must not change the internal cache."""
+    coord = _make_coordinator(hass, AsyncMock())
+    snapshot = coord.tariff_setup
+
+    snapshot["low"]["socMin"] = 99
+    snapshot["high"] = {"hijacked": True}
+
+    # Internal cache stayed untouched
+    assert coord.tariff_setup["low"]["socMin"] != 99
+    assert "hijacked" not in coord.tariff_setup["high"]
+
+
+# ---------- 500003 reject case ----------
+
+
+async def test_async_push_does_not_swallow_api_error(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    """A 500003 (or any other API error) must propagate so callers can roll back."""
+    api = AsyncMock()
+    api.set_tariff_strategy.side_effect = SunlitApiError(
+        "API error: Service temporarily unavailable"
+    )
+    coord = _make_coordinator(hass, api)
+
+    coord.update_tariff_setup_field("high", "strategy", "EnergyStorageOnly")
+
+    with pytest.raises(SunlitApiError):
+        await coord.async_push_tariff_setup()

--- a/tests/test_tariff_strategy_readback.py
+++ b/tests/test_tariff_strategy_readback.py
@@ -1,0 +1,196 @@
+"""Tests for the cloud→HA tariff readback path.
+
+Cedric's PR #201 review (item 1) asked for:
+  - find the GET-style endpoint the app uses to render the tariff setup
+  - add it to the api client
+  - have the coordinator's _async_update_data reconcile its cache from it
+  - that makes the cache cloud-authoritative and the rollback path correct
+    rather than best-effort
+
+The endpoint turned out to be POST /v1.8/strategy/setting/detail with
+strategyType=TariffStrategy. The fixture mirrors a real captured response.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.sunlit.api_client import SunlitApiError
+from custom_components.sunlit.coordinators.strategy import (
+    SunlitStrategyHistoryCoordinator,
+)
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "api"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+def _make_coordinator(
+    hass: HomeAssistant, api_client: AsyncMock
+) -> SunlitStrategyHistoryCoordinator:
+    coord = SunlitStrategyHistoryCoordinator(
+        hass=hass,
+        api_client=api_client,
+        family_id="40566",
+        family_name="Balkon",
+    )
+    coord.async_request_refresh = AsyncMock()
+    return coord
+
+
+def _api_with_tariff_active() -> AsyncMock:
+    """Wire up an api client whose readback returns a known tariff setup."""
+    api = AsyncMock()
+    raw = _load("strategy_setting_detail_tariff_active.json")
+    tariff = raw["content"]["tariffStrategy"]
+    api.fetch_tariff_setup.return_value = {
+        "low": tariff["lowPriceStrategy"],
+        "high": tariff["highPriceStrategy"],
+        "enableSwitchNotice": tariff["enableSwitchNotice"],
+    }
+    api.fetch_space_strategy_history.return_value = {"content": []}
+    return api
+
+
+# ---------- happy path: cache wins back from cloud ----------
+
+
+async def test_readback_overwrites_divergent_cache(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    """If the cache says one thing and the cloud says another, cloud wins.
+
+    This is the core scenario Cedric's review asked us to cover: the user
+    just edited the strategy in the SunEnergyXT app, the cloud now reflects
+    that, but our HA cache still holds the previous values. After the next
+    coordinator refresh the cache must mirror the cloud.
+    """
+    api = _api_with_tariff_active()
+    coord = _make_coordinator(hass, api)
+
+    # Pre-populate the cache with values different from what the cloud has.
+    coord.update_tariff_setup_field("low", "socMin", 50)
+    coord.update_tariff_setup_field("low", "socMax", 60)
+    coord.update_tariff_setup_field("high", "strategy", "Manual")
+    coord.update_tariff_setup_field("high", "socMin", 80)
+
+    await coord._async_update_data()
+
+    # Cloud values (from the fixture) should now sit in the cache.
+    assert coord.tariff_setup["low"]["strategy"] == "EnergyStorageOnly"
+    assert coord.tariff_setup["low"]["socMin"] == 1
+    assert coord.tariff_setup["low"]["socMax"] == 90
+    assert coord.tariff_setup["high"]["strategy"] == "SmartStrategy"
+    assert coord.tariff_setup["high"]["socMin"] == 10
+    assert coord.tariff_setup["high"]["socMax"] == 100
+
+
+async def test_readback_called_with_family_id(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    """The coordinator must read back its own family — verifies wiring."""
+    api = _api_with_tariff_active()
+    coord = _make_coordinator(hass, api)
+
+    await coord._async_update_data()
+
+    api.fetch_tariff_setup.assert_called_once_with("40566")
+
+
+# ---------- defensive: missing / disabled / failing readback ----------
+
+
+async def test_readback_returning_none_leaves_cache_untouched(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    """No tariff strategy configured on cloud side: cache must keep its values.
+
+    This is the 'fresh install' case — the user has never configured a
+    tariff strategy yet. We must not clobber the defaults with empty data.
+    """
+    api = AsyncMock()
+    api.fetch_tariff_setup.return_value = None
+    api.fetch_space_strategy_history.return_value = {"content": []}
+    coord = _make_coordinator(hass, api)
+
+    coord.update_tariff_setup_field("low", "socMin", 42)
+
+    await coord._async_update_data()
+
+    assert coord.tariff_setup["low"]["socMin"] == 42
+
+
+async def test_readback_api_error_does_not_break_history_fetch(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    """A failing readback must not abort the regular history update.
+
+    History data is what surfaces on the dashboard tile; the readback is
+    only for cache sanity. A flaky readback shouldn't take down the tile.
+    """
+    api = AsyncMock()
+    api.fetch_tariff_setup.side_effect = SunlitApiError("readback boom")
+    api.fetch_space_strategy_history.return_value = {
+        "content": [
+            {
+                "modifyDate": 1780000000000,
+                "strategy": "TariffStrategy",
+                "status": "ACTIVE",
+            }
+        ]
+    }
+    coord = _make_coordinator(hass, api)
+
+    data = await coord._async_update_data()
+
+    assert "strategy" in data
+    assert data["strategy"]["last_strategy_type"] == "TariffStrategy"
+
+
+async def test_readback_skips_none_fields(
+    hass: HomeAssistant, enable_custom_integrations
+):
+    """Cloud sometimes reports a field as null — keep our cached value then.
+
+    Captured responses regularly carry e.g. ``socMin: null`` in the
+    high-price block depending on strategy type. Treating null as
+    'overwrite' would zero out the cache; we instead treat null as
+    'cloud has no opinion here'.
+    """
+    api = AsyncMock()
+    # Construct a readback where socMin is null — must not overwrite cache.
+    api.fetch_tariff_setup.return_value = {
+        "low": {
+            "strategy": "EnergyStorageOnly",
+            "socMin": None,
+            "socMax": 90,
+            "defaultExpectInverterOutput": 300.0,
+        },
+        "high": {
+            "strategy": "SmartStrategy",
+            "socMin": None,
+            "socMax": 100,
+        },
+        "enableSwitchNotice": True,
+    }
+    api.fetch_space_strategy_history.return_value = {"content": []}
+    coord = _make_coordinator(hass, api)
+
+    coord.update_tariff_setup_field("low", "socMin", 5)
+    coord.update_tariff_setup_field("high", "socMin", 15)
+
+    await coord._async_update_data()
+
+    # socMin stayed because cloud sent null; socMax overwritten because cloud sent value.
+    assert coord.tariff_setup["low"]["socMin"] == 5
+    assert coord.tariff_setup["low"]["socMax"] == 90
+    assert coord.tariff_setup["high"]["socMin"] == 15
+    assert coord.tariff_setup["high"]["socMax"] == 100


### PR DESCRIPTION
## What this PR does

Adds six new Home Assistant entities per family that let you switch the battery strategy for the **low- and high-price windows of a dynamic electricity tariff** (Tibber, Rabot Charge, …) directly from HA. Until now this had to be done through the SunEnergyXT app.

This is the cloud-API path for issue #174 — it works even when the local P200 TCP slot is occupied by the cloud (which is the normal case while the cloud connection is live), so HA has no direct local write access to the BK215.

## New entities (per family)

**2 × `select`** — strategy per price band:
- `select.<family>_low_price_strategy`
- `select.<family>_high_price_strategy`
- options: `EnergyStorageOnly`, `SmartStrategy`, `Manual`

**4 × `number`** — SOC limits per price band (1–100 %, slider):
- `number.<family>_low_price_soc_min` / `_soc_max`
- `number.<family>_high_price_soc_min` / `_soc_max`

All six are attached to the existing family device.

## Why it's built this way (for reviewers without prior context)

The cloud endpoint `POST /v1.6/tariffStrategy/add` is **all-or-nothing**: every call must carry the full low **and** the full high block. There is no endpoint that updates a single field.

To still let the HA entities feel independent (e.g. you can change just `low_price_soc_max`), the existing `SunlitStrategyHistoryCoordinator` now keeps an in-memory cache of the last sent values. Every entity edit mutates one field of that cache, then the coordinator pushes the full bundle out.

```
HA entity edit
   └─> coordinator.update_tariff_setup_field(band, field, value)
        └─> coordinator.async_push_tariff_setup()
             └─> api_client.set_tariff_strategy(low_full, high_full)
                  └─> POST /v1.6/tariffStrategy/add
```

The cache is initialised with sensible defaults (`EnergyStorageOnly`/Smart, 1/100 and 10/100 % respectively) and overwritten from `RestoreEntity` with the last seen state on HA startup — i.e. an HA restart cannot silently change anything in the cloud as long as the user doesn't click anything in HA. As of the latest review round it is also reconciled against the cloud's authoritative view via `POST /v1.8/strategy/setting/detail` on every coordinator refresh, so out-of-band edits in the SunEnergyXT app no longer get overwritten by the next entity push.

## What reviewers should know

1. **Server-side validation**: the cloud rejects logically invalid combinations with `code: 500003` and the message "Service temporarily unavailable". Observed:
   - `EnergyStorageOnly` as the **high-price** strategy (storing instead of discharging during expensive tariff windows → makes no sense)
   - probably also `Manual` without further manual fields; I haven't tested that systematically.
   These errors surface as `HomeAssistantError` in the UI; the cached value is overwritten with the actual cloud state on the next coordinator refresh, so the entity does not stay "falsely green".

2. **Client-side sanity checks** (`number.py`): before each push the code verifies `socMin < socMax` within the same band. If not, a `HomeAssistantError` is raised immediately, no API round-trip.

3. **`defaultExpectInverterOutput`** is only sent on the low-price block via the API (per the issue documentation). The default is 800 W (BK215 configuration for Germany). It is currently **not exposed as its own number entity** — the default is sent through unchanged. If users want it surfaced in the UI, that can come in a follow-up PR.

4. **No new dependencies**, no config-flow changes. Existing installations get the entities automatically on next reload/restart because `Platform.SELECT` and `Platform.NUMBER` are added to the `PLATFORMS` list.

5. **No migration needed**: no storage version bump, no existing entities renamed or removed.

## Files changed/added

| File | Change |
|---|---|
| `const.py` | + endpoint paths `API_TARIFF_STRATEGY_ADD`, `API_STRATEGY_SETTING_DETAIL`, options list, defaults |
| `api_client.py` | + `set_tariff_strategy(family_id, low, high, …)`, + `fetch_tariff_setup(family_id)` |
| `coordinators/strategy.py` | + in-memory cache `_tariff_setup`, `update_tariff_setup_field`, `async_push_tariff_setup`, cloud reconcile in `_async_update_data` |
| `select.py` | **new** — `SunlitTariffStrategySelect` (low + high) |
| `number.py` | **new** — `SunlitTariffSocNumber` (4 fields) |
| `__init__.py` | + `Platform.SELECT`, `Platform.NUMBER` in `PLATFORMS` |
| `openapi.yaml` | documented `/v1.6/tariffStrategy/add` (with the `code: 500003` reject example) and `/v1.8/strategy/setting/detail` |
| `tests/fixtures/api/` | accepted/rejected envelopes for `tariffStrategy/add`, active/disabled examples for `strategy/setting/detail` |
| `tests/test_tariff_strategy_*.py` | coordinator + entity + readback coverage (push, rollback, validation, restore, reconciliation) |

## Live test against a BK215 in Germany

Tested against a real BK215 (family ID 40566) on HA Core 2026.5.4:

| Test | Result |
|---|---|
| `number.set_value` `high_price_soc_min` 10 → 15 → 10 | ✅ HTTP 200, cloud `code: 0`, HA state follows |
| `select.select_option` `high_price_strategy` SmartStrategy → SmartStrategy (no-op) | ✅ HTTP 200, cloud `code: 0` |
| `select.select_option` `high_price_strategy` SmartStrategy → EnergyStorageOnly (logically invalid) | ⚠️ cloud rejects with `code: 500003`, HA raises `HomeAssistantError`, state stays on SmartStrategy — as intended |
| HA restart → restore | ✅ values reappear from last state; no automatic push to the cloud |

## Test plan for reviewers

- [ ] Reload the integration → 2× select + 4× number show up under the family device with their defaults
- [ ] `number.set_value` for `low_price_soc_max` writes a sensible value; state reflects it
- [ ] `select.select_option` with a valid combination is accepted
- [ ] `select.select_option` with an invalid combination (e.g. EnergyStorageOnly as high) → `HomeAssistantError`, state unchanged
- [ ] HA restart → values from last state come back, no unwanted cloud write
- [ ] Check the SunEnergyXT app to confirm it shows the same state as HA

Closes #174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-family tariff strategy selects for low/high bands (EnergyStorageOnly, SmartStrategy, Manual).
  * Sliders to configure min/max state-of-charge (%) for each tariff band.
  * Settings persist, restore on startup, and are pushed to the remote service.

* **Bug Fixes / Reliability**
  * Invalid SOC ranges are blocked; failed pushes roll back changes to the previous value.

* **Tests**
  * Added tests covering entity behavior, restore, validation, push/rollback, and coordinator push logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/ha-sunlit/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
