### PR TITLE
feat(local): add BK215 TCP protocol decoder and client

### DIFF
--- a/custom_components/sunlit/local/__init__.py
+++ b/custom_components/sunlit/local/__init__.py
@@ -1,0 +1,9 @@
+"""Opt-in local-mode (TCP) channel for the BK215 battery.
+
+When a battery has local mode enabled and its LAN address is known (from
+zeroconf), the integration can talk to it directly over TCP for real-time push
+telemetry instead of waiting on the 30 s cloud poll. The cloud channel stays
+authoritative and acts as the floor if the local connection drops.
+
+See ``docs/local-protocol.md`` for the reverse-engineered protocol reference.
+"""

--- a/custom_components/sunlit/local/protocol.py
+++ b/custom_components/sunlit/local/protocol.py
@@ -1,0 +1,256 @@
+"""BK215 local-mode TCP protocol: framing, register decode, set payloads.
+
+Clean-room reimplementation from ``docs/local-protocol.md`` (a behavioural spec
+only). This module is intentionally Home Assistant-agnostic and side-effect
+free so it can be unit-tested against a plain asyncio socket.
+
+The device pushes newline-delimited compact JSON envelopes::
+
+    {"code": 24658, "data": {"t211": 50, "t33": 97, ...}}
+
+``code`` selects the envelope kind (telemetry vs set-ack); ``data`` maps
+``tNNN`` register names to raw integers. Unset registers carry the sentinel
+``0xFFFFFFFF`` and must be ignored.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import json
+from typing import Any
+
+# --- Transport -------------------------------------------------------------
+
+# Observed TCP control port. The mDNS A-record gives the host; the control
+# port is advertised in the TXT ``port`` property (not the _http service port).
+DEFAULT_PORT = 8000
+
+# A register carrying this value is unset and should be treated as "no data".
+UNSET = 0xFFFFFFFF
+
+# --- Message codes ---------------------------------------------------------
+
+CODE_SET = 0x6056  # client -> device: write one or more registers
+CODE_SET_ACK = 0x6057  # device -> client: write ack (field == 0 => success)
+
+# device -> client: unsolicited telemetry pushes (three interleaved kinds)
+TELEMETRY_CODES = frozenset({0x6052, 0x6055, 0x6060})
+
+
+# --- Value scaling ---------------------------------------------------------
+
+Decoder = Callable[[int], Any]
+
+
+def _linear(factor: float, ndigits: int) -> Decoder:
+    """Decode ``raw * factor`` rounded to ``ndigits`` (0 => int)."""
+
+    def decode(raw: int) -> float | int:
+        value = raw * factor
+        return round(value) if ndigits == 0 else round(value, ndigits)
+
+    return decode
+
+
+def _offset(offset: int) -> Decoder:
+    """Decode ``raw - offset`` (used for Kelvin-ish cell temperatures)."""
+    return lambda raw: raw - offset
+
+
+def heater_bits(raw: int) -> list[bool]:
+    """Split the ``t586`` heater bitfield into per-unit booleans.
+
+    Bit 0 is the main unit, bits 1..7 are extension modules 1..7.
+    """
+    if raw == UNSET:
+        return []
+    return [bool((raw >> bit) & 1) for bit in range(8)]
+
+
+# --- Register map ----------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Register:
+    """Decoding metadata for one ``tNNN`` register."""
+
+    decode: Decoder
+    unit: str | None = None
+    device_class: str | None = None
+
+
+def _battery(raw_unit: str = "%") -> Register:
+    return Register(_linear(1, 0), raw_unit, "battery")
+
+
+def _power() -> Register:
+    return Register(_linear(1, 0), "W", "power")
+
+
+def _pv_power() -> Register:
+    # PV input power is reported centi-watts.
+    return Register(_linear(0.01, 2), "W", "power")
+
+
+def _energy() -> Register:
+    return Register(_linear(0.001, 3), "kWh", "energy")
+
+
+def _voltage() -> Register:
+    return Register(_linear(0.1, 1), "V", "voltage")
+
+
+def _current() -> Register:
+    return Register(_linear(0.1, 1), "A", "current")
+
+
+def _temperature() -> Register:
+    return Register(_offset(273), "°C", "temperature")
+
+
+# Module SOC registers: head unit (t592) + modules 1..7. The slot ordering is
+# t593,t594,t595 then jumps to t1001..t1004 for modules 4..7.
+_MODULE_SOC = ["t592", "t593", "t594", "t595", "t1001", "t1002", "t1003", "t1004"]
+# Per-module MPPT (voltage, current) register pairs, modules 1..7.
+_MODULE_MPPT = [
+    ("t552", "t553"),
+    ("t560", "t561"),
+    ("t568", "t569"),
+    ("t969", "t970"),
+    ("t977", "t978"),
+    ("t985", "t986"),
+    ("t993", "t994"),
+]
+# Min cell temperature per unit: head (t220) + modules 1..7.
+_CELL_TEMP = ["t220", "t233", "t246", "t259", "t836", "t849", "t862", "t875"]
+
+
+def _build_registers() -> dict[str, Register]:
+    regs: dict[str, Register] = {
+        "t211": _battery(),  # system SOC (remaining capacity)
+        "t33": _power(),  # total input power
+        "t34": _power(),  # total output power
+        "t49": _energy(),  # daily generation
+        "t66": _energy(),  # daily output energy
+        "t710": _energy(),  # charging-box daily AC-charge energy
+        "t711": _power(),  # charging-box AC input power
+        "t701_4": _power(),  # car-charge mode power
+        "t702_4": _power(),  # home-appliance mode power
+        # main MPPT 1 & 2 (voltage, current)
+        "t536": _voltage(),
+        "t537": _current(),
+        "t544": _voltage(),
+        "t545": _current(),
+        "t586": Register(int, None, None),  # heater bitfield (use heater_bits)
+        "t475": Register(int, "dB", "signal_strength"),  # RSSI (see decode note)
+    }
+    # SOC per unit
+    for reg in _MODULE_SOC:
+        regs[reg] = _battery()
+    # PV1..PV9 input power
+    for reg in ("t50", "t62", "t63", "t64", "t65", "t812", "t813", "t814", "t815"):
+        regs[reg] = _pv_power()
+    # per-module MPPT pairs
+    for vol_reg, cur_reg in _MODULE_MPPT:
+        regs[vol_reg] = _voltage()
+        regs[cur_reg] = _current()
+    # cell temperatures
+    for reg in _CELL_TEMP:
+        regs[reg] = _temperature()
+    return regs
+
+
+REGISTERS: dict[str, Register] = _build_registers()
+
+
+def decode_telemetry(data: dict[str, int]) -> dict[str, Any]:
+    """Decode a raw telemetry ``data`` map into scaled values.
+
+    Unset registers (``0xFFFFFFFF``) and unknown register names are dropped.
+    Known registers are scaled per their :class:`Register` definition.
+    """
+    decoded: dict[str, Any] = {}
+    for name, raw in data.items():
+        if raw == UNSET:
+            continue
+        register = REGISTERS.get(name)
+        if register is None:
+            continue
+        decoded[name] = register.decode(raw)
+    return decoded
+
+
+# --- Framing ---------------------------------------------------------------
+
+
+def is_protocol_line(line: str) -> bool:
+    """Return whether ``line`` is a single, well-formed protocol envelope.
+
+    Filters out blank lines, ``0xAA`` keepalive bytes, and any line that does
+    not look like exactly one ``{"code": ...}`` object.
+    """
+    stripped = line.strip()
+    if not stripped:
+        return False
+    lowered = stripped.lower()
+    if "\\xaa" in lowered or "code" not in lowered:
+        return False
+    if not lowered.startswith('{"code":'):
+        return False
+    # Guard against concatenated objects on one line.
+    return lowered.count("code") == 1
+
+
+def parse_message(line: str) -> tuple[int, dict[str, int]] | None:
+    """Parse one protocol line into ``(code, data)`` or ``None`` if invalid."""
+    if not is_protocol_line(line):
+        return None
+    try:
+        envelope = json.loads(line)
+    except (ValueError, TypeError):
+        return None
+    code = envelope.get("code")
+    if not isinstance(code, int):
+        return None
+    data = envelope.get("data") or {}
+    if not isinstance(data, dict):
+        return None
+    return code, data
+
+
+def iter_messages(buffer: str) -> tuple[list[tuple[int, dict[str, int]]], str]:
+    """Split a raw read ``buffer`` into parsed messages and a leftover tail.
+
+    Returns ``(messages, remainder)`` where ``remainder`` is an unterminated
+    trailing fragment to be prepended to the next read.
+    """
+    messages: list[tuple[int, dict[str, int]]] = []
+    *complete, remainder = buffer.split("\n")
+    for line in complete:
+        parsed = parse_message(line)
+        if parsed is not None:
+            messages.append(parsed)
+    return messages, remainder
+
+
+# --- Writing registers -----------------------------------------------------
+
+
+def build_set_payload(field: str, value: int) -> str:
+    """Build a ``code 0x6056`` set request carrying only ``field``.
+
+    The device expects every unchanged register to be omitted (it treats them
+    as the unset sentinel), so we send a minimal envelope with just the one
+    field being written, as newline-terminated compact JSON.
+    """
+    envelope = {"code": CODE_SET, "data": {field: value}}
+    return json.dumps(envelope, separators=(",", ":")) + "\n"
+
+
+def is_set_ack_success(field: str, data: dict[str, int]) -> bool:
+    """Return whether a set-ack ``data`` map reports success for ``field``.
+
+    The device acks a write by echoing the field with value ``0``.
+    """
+    return data.get(field) == 0

--- a/custom_components/sunlit/local/protocol.py
+++ b/custom_components/sunlit/local/protocol.py
@@ -216,6 +216,14 @@ def parse_message(line: str) -> tuple[int, dict[str, int]] | None:
     data = envelope.get("data") or {}
     if not isinstance(data, dict):
         return None
+    # Every register entry must be a string key mapped to a plain int; reject
+    # the whole message if any value is a string/bool/float so downstream
+    # scaling (raw * factor) doesn't blow up at runtime.
+    for key, value in data.items():
+        if not isinstance(key, str):
+            return None
+        if not isinstance(value, int) or isinstance(value, bool):
+            return None
     return code, data
 
 

--- a/custom_components/sunlit/local/tcp_client.py
+++ b/custom_components/sunlit/local/tcp_client.py
@@ -1,0 +1,206 @@
+"""Asyncio TCP client for the BK215 local-mode channel.
+
+A single persistent connection per battery. The device pushes telemetry
+unsolicited; we decode it and hand it to ``on_telemetry``. Writes go out as
+``0x6056`` set requests and resolve when the matching ``0x6057`` ack arrives.
+
+The client owns its own reconnect lifecycle: :meth:`start` launches a
+background task that connects, listens, and re-dials on drop until
+:meth:`async_stop` is called. It is deliberately Home Assistant-agnostic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+import contextlib
+import logging
+from typing import Any
+
+from .protocol import (
+    CODE_SET_ACK,
+    DEFAULT_PORT,
+    TELEMETRY_CODES,
+    build_set_payload,
+    decode_telemetry,
+    is_set_ack_success,
+    iter_messages,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+CONNECT_TIMEOUT = 5.0  # seconds to establish the TCP connection
+HEARTBEAT_TIMEOUT = 60.0  # silence after which we assume the link is dead
+RECONNECT_DELAY = 5.0  # backoff between reconnect attempts
+READ_SIZE = 2048  # bytes per socket read
+MAX_BUFFER = 65536  # drop a runaway line that never terminates
+SET_TIMEOUT = 2.0  # seconds to wait for a set ack
+
+
+class BK215LocalClient:
+    """Persistent TCP client for one BK215 battery."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int = DEFAULT_PORT,
+        *,
+        on_telemetry: Callable[[dict[str, Any]], None] | None = None,
+        on_state_change: Callable[[bool], None] | None = None,
+        name: str | None = None,
+    ) -> None:
+        """Initialize the client.
+
+        Args:
+            host: LAN address of the battery (from zeroconf).
+            port: TCP control port (defaults to the observed 8000).
+            on_telemetry: called with each decoded telemetry map.
+            on_state_change: called with the new ``connected`` value on change.
+            name: label for log lines (e.g. the serial number).
+        """
+        self._host = host
+        self._port = port
+        self._on_telemetry = on_telemetry
+        self._on_state_change = on_state_change
+        self._name = name or f"{host}:{port}"
+
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._task: asyncio.Task | None = None
+        self._closing = False
+        self._connected = False
+        self._pending_acks: dict[str, list[asyncio.Future[bool]]] = {}
+
+    @property
+    def connected(self) -> bool:
+        """Whether the socket is currently up."""
+        return self._connected
+
+    def start(self) -> None:
+        """Launch the connect/listen/reconnect background task."""
+        if self._task is not None and not self._task.done():
+            return
+        self._closing = False
+        self._task = asyncio.create_task(self._run(), name=f"bk215-local-{self._name}")
+
+    async def async_stop(self) -> None:
+        """Stop the client and close the connection."""
+        self._closing = True
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+        await self._close_connection()
+        self._fail_pending_acks()
+
+    async def set_register(
+        self, field: str, value: int, timeout: float = SET_TIMEOUT
+    ) -> bool:
+        """Write a single register and wait for the device's ack.
+
+        Returns True on a success ack, False if not connected, the write
+        fails, or no successful ack arrives within ``timeout``.
+        """
+        if not self._connected or self._writer is None:
+            return False
+
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[bool] = loop.create_future()
+        self._pending_acks.setdefault(field, []).append(future)
+        try:
+            self._writer.write(build_set_payload(field, value).encode("ascii"))
+            await self._writer.drain()
+            return await asyncio.wait_for(future, timeout)
+        except (TimeoutError, OSError) as err:
+            _LOGGER.debug("[%s] set %s=%s failed: %s", self._name, field, value, err)
+            return False
+        finally:
+            waiters = self._pending_acks.get(field)
+            if waiters and future in waiters:
+                waiters.remove(future)
+            if waiters is not None and not waiters:
+                self._pending_acks.pop(field, None)
+
+    # --- internals ---------------------------------------------------------
+
+    async def _run(self) -> None:
+        """Connect, listen, and re-dial until stopped."""
+        while not self._closing:
+            try:
+                await self._connect()
+                await self._listen()
+            except asyncio.CancelledError:
+                raise
+            except (OSError, TimeoutError) as err:
+                _LOGGER.debug("[%s] connection error: %s", self._name, err)
+            finally:
+                await self._close_connection()
+            if self._closing:
+                break
+            await asyncio.sleep(RECONNECT_DELAY)
+
+    async def _connect(self) -> None:
+        self._reader, self._writer = await asyncio.wait_for(
+            asyncio.open_connection(self._host, self._port), CONNECT_TIMEOUT
+        )
+        self._set_connected(True)
+        _LOGGER.info("[%s] connected", self._name)
+
+    async def _listen(self) -> None:
+        """Read and dispatch frames until EOF, error, or heartbeat timeout."""
+        assert self._reader is not None
+        buffer = ""
+        while not self._closing:
+            data = await asyncio.wait_for(
+                self._reader.read(READ_SIZE), HEARTBEAT_TIMEOUT
+            )
+            if not data:  # EOF: peer closed the connection
+                _LOGGER.debug("[%s] peer closed connection", self._name)
+                break
+            buffer += data.decode("ascii", errors="ignore")
+            messages, buffer = iter_messages(buffer)
+            for code, payload in messages:
+                self._handle_message(code, payload)
+            if len(buffer) > MAX_BUFFER:  # never-terminated junk: drop it
+                buffer = ""
+
+    def _handle_message(self, code: int, data: dict[str, int]) -> None:
+        if code in TELEMETRY_CODES:
+            decoded = decode_telemetry(data)
+            if decoded and self._on_telemetry is not None:
+                self._on_telemetry(decoded)
+        elif code == CODE_SET_ACK:
+            self._resolve_acks(data)
+
+    def _resolve_acks(self, data: dict[str, int]) -> None:
+        for field in list(self._pending_acks):
+            if field not in data:
+                continue
+            success = is_set_ack_success(field, data)
+            for future in self._pending_acks.get(field, []):
+                if not future.done():
+                    future.set_result(success)
+
+    def _fail_pending_acks(self) -> None:
+        for waiters in self._pending_acks.values():
+            for future in waiters:
+                if not future.done():
+                    future.set_result(False)
+        self._pending_acks.clear()
+
+    async def _close_connection(self) -> None:
+        self._set_connected(False)
+        if self._writer is not None:
+            self._writer.close()
+            with contextlib.suppress(OSError, asyncio.TimeoutError):
+                await asyncio.wait_for(self._writer.wait_closed(), CONNECT_TIMEOUT)
+        self._reader = None
+        self._writer = None
+
+    def _set_connected(self, value: bool) -> None:
+        if value == self._connected:
+            return
+        self._connected = value
+        if self._on_state_change is not None:
+            self._on_state_change(value)

--- a/custom_components/sunlit/local/tcp_client.py
+++ b/custom_components/sunlit/local/tcp_client.py
@@ -169,7 +169,7 @@ class BK215LocalClient:
         if code in TELEMETRY_CODES:
             decoded = decode_telemetry(data)
             if decoded and self._on_telemetry is not None:
-                self._on_telemetry(decoded)
+                self._safe_callback("on_telemetry", self._on_telemetry, decoded)
         elif code == CODE_SET_ACK:
             self._resolve_acks(data)
 
@@ -203,4 +203,15 @@ class BK215LocalClient:
             return
         self._connected = value
         if self._on_state_change is not None:
-            self._on_state_change(value)
+            self._safe_callback("on_state_change", self._on_state_change, value)
+
+    def _safe_callback(self, name: str, callback: Callable, *args: Any) -> None:
+        """Invoke a user callback; log and swallow any exception.
+
+        Callbacks run on the listen task; an unhandled exception there would
+        terminate the background loop and silently disable the client.
+        """
+        try:
+            callback(*args)
+        except Exception:  # pragma: no cover - defensive isolation
+            _LOGGER.exception("[%s] %s callback raised", self._name, name)

--- a/tests/test_local_protocol.py
+++ b/tests/test_local_protocol.py
@@ -77,6 +77,22 @@ def test_parse_message():
     assert protocol.parse_message("not json") is None
 
 
+def test_parse_message_rejects_non_integer_data_values():
+    """Strings, floats, and bools in data values reject the whole message.
+
+    decode_telemetry multiplies by a scale factor; admitting strings/floats
+    would either crash or quietly poison entity state.
+    """
+    assert protocol.parse_message('{"code":24658,"data":{"t211":"50"}}') is None
+    assert protocol.parse_message('{"code":24658,"data":{"t211":1.5}}') is None
+    assert protocol.parse_message('{"code":24658,"data":{"t211":true}}') is None
+    # A non-string key would be unusual but also invalid for a register name.
+    assert protocol.parse_message('{"code":24658,"data":{"1":50}}') == (
+        24658,
+        {"1": 50},
+    )
+
+
 def test_iter_messages_buffers_partial_line():
     """A trailing unterminated fragment is returned as the remainder."""
     buffer = '{"code":24658,"data":{"t33":1}}\n{"code":24661,"data":{"t34":2'

--- a/tests/test_local_protocol.py
+++ b/tests/test_local_protocol.py
@@ -1,0 +1,106 @@
+"""Tests for the BK215 local-mode protocol decode and framing."""
+
+from __future__ import annotations
+
+import json
+
+from custom_components.sunlit.local import protocol
+
+
+def test_decode_value_scaling():
+    """Each scaling convention decodes per docs/local-protocol.md."""
+    decoded = protocol.decode_telemetry(
+        {
+            "t211": 50,  # battery %, raw
+            "t33": 97,  # power W, raw
+            "t49": 1234,  # energy kWh, x0.001
+            "t50": 5000,  # PV power W, x0.01
+            "t536": 430,  # MPPT voltage V, x0.1
+            "t537": 21,  # MPPT current A, x0.1
+            "t220": 298,  # cell temp degC, -273
+        }
+    )
+    assert decoded["t211"] == 50
+    assert decoded["t33"] == 97
+    assert decoded["t49"] == 1.234
+    assert decoded["t50"] == 50.0
+    assert decoded["t536"] == 43.0
+    assert decoded["t537"] == 2.1
+    assert decoded["t220"] == 25
+
+
+def test_decode_drops_unset_sentinel():
+    """0xFFFFFFFF registers are omitted from the decoded map."""
+    decoded = protocol.decode_telemetry({"t211": protocol.UNSET, "t33": 100})
+    assert "t211" not in decoded
+    assert decoded["t33"] == 100
+
+
+def test_decode_drops_unknown_registers():
+    """Registers not in the map are ignored rather than passed through raw."""
+    decoded = protocol.decode_telemetry({"t999": 5, "t211": 42})
+    assert decoded == {"t211": 42}
+
+
+def test_module_soc_registers_present():
+    """Head unit plus seven module SOC slots all decode as battery %."""
+    raw = dict.fromkeys(["t592", "t593", "t595", "t1001", "t1004"], 80)
+    decoded = protocol.decode_telemetry(raw)
+    assert all(decoded[reg] == 80 for reg in raw)
+
+
+def test_heater_bits():
+    """The t586 bitfield splits into head + module booleans."""
+    # bits 0 (main) and 2 (module 2) set => 0b101 = 5
+    bits = protocol.heater_bits(0b101)
+    assert bits[0] is True
+    assert bits[1] is False
+    assert bits[2] is True
+    assert protocol.heater_bits(protocol.UNSET) == []
+
+
+def test_is_protocol_line_filters():
+    """Blank, keepalive, and malformed lines are rejected."""
+    assert protocol.is_protocol_line('{"code":24658,"data":{"t211":50}}')
+    assert not protocol.is_protocol_line("")
+    assert not protocol.is_protocol_line("   ")
+    assert not protocol.is_protocol_line(r"\xaa\xaa")
+    assert not protocol.is_protocol_line("garbage")
+    # two concatenated objects on one line are rejected
+    assert not protocol.is_protocol_line('{"code":1}{"code":2}')
+
+
+def test_parse_message():
+    """A valid line parses into (code, data)."""
+    parsed = protocol.parse_message('{"code":24658,"data":{"t211":50}}')
+    assert parsed == (24658, {"t211": 50})
+    assert protocol.parse_message("not json") is None
+
+
+def test_iter_messages_buffers_partial_line():
+    """A trailing unterminated fragment is returned as the remainder."""
+    buffer = '{"code":24658,"data":{"t33":1}}\n{"code":24661,"data":{"t34":2'
+    messages, remainder = protocol.iter_messages(buffer)
+    assert messages == [(24658, {"t33": 1})]
+    assert remainder == '{"code":24661,"data":{"t34":2'
+
+    # Feeding the remainder + rest yields the second message.
+    messages, remainder = protocol.iter_messages(remainder + "}}\n")
+    assert messages == [(24661, {"t34": 2})]
+    assert remainder == ""
+
+
+def test_build_set_payload_minimal_and_terminated():
+    """A set payload carries only the changed field and ends in a newline."""
+    payload = protocol.build_set_payload("t598", 1)
+    assert payload.endswith("\n")
+    envelope = json.loads(payload)
+    assert envelope == {"code": protocol.CODE_SET, "data": {"t598": 1}}
+    assert " " not in payload  # compact separators
+
+
+def test_is_set_ack_success():
+    """A field echoed as 0 means success; anything else is failure."""
+    assert protocol.is_set_ack_success("t598", {"t598": 0})
+    assert not protocol.is_set_ack_success("t598", {"t598": 1})
+    assert not protocol.is_set_ack_success("t598", {})

--- a/tests/test_local_tcp_client.py
+++ b/tests/test_local_tcp_client.py
@@ -1,0 +1,172 @@
+"""Tests for the BK215 local-mode TCP client against a loopback mock server."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from custom_components.sunlit.local import protocol
+from custom_components.sunlit.local.tcp_client import BK215LocalClient
+
+
+class MockBK215Server:
+    """A minimal asyncio TCP server mimicking the battery's push protocol.
+
+    Pushes any queued telemetry lines to a connecting client and, on receiving
+    a ``0x6056`` set request, replies with a ``0x6057`` ack echoing the field
+    as ``0`` (success).
+    """
+
+    def __init__(self) -> None:
+        self._server: asyncio.AbstractServer | None = None
+        self.port = 0
+        self.connections = 0
+        self.received: list[dict] = []
+        self._push_lines: list[str] = []
+        self.ack_value = 0  # value echoed back in the set ack
+
+    def queue_telemetry(self, code: int, data: dict) -> None:
+        self._push_lines.append(json.dumps({"code": code, "data": data}) + "\n")
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_server(
+            self._handle, host="127.0.0.1", port=0
+        )
+        self.port = self._server.sockets[0].getsockname()[1]
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+
+    async def _handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        self.connections += 1
+        for line in self._push_lines:
+            writer.write(line.encode("ascii"))
+        await writer.drain()
+        try:
+            while True:
+                raw = await reader.readline()
+                if not raw:
+                    break
+                parsed = protocol.parse_message(raw.decode("ascii").strip())
+                if parsed is None:
+                    continue
+                code, data = parsed
+                self.received.append({"code": code, "data": data})
+                if code == protocol.CODE_SET:
+                    field = next(iter(data))
+                    ack = {
+                        "code": protocol.CODE_SET_ACK,
+                        "data": {field: self.ack_value},
+                    }
+                    writer.write((json.dumps(ack) + "\n").encode("ascii"))
+                    await writer.drain()
+        except (ConnectionResetError, asyncio.CancelledError):
+            pass
+        finally:
+            writer.close()
+
+
+@pytest.fixture
+async def server(socket_enabled):
+    """A loopback mock server. ``socket_enabled`` lifts the HA socket block."""
+    srv = MockBK215Server()
+    await srv.start()
+    yield srv
+    await srv.stop()
+
+
+async def test_receives_and_decodes_telemetry(server: MockBK215Server):
+    """Pushed telemetry is decoded and delivered to the callback."""
+    server.queue_telemetry(0x6052, {"t211": 50, "t33": 97, "t536": 430})
+
+    received: list[dict] = []
+    client = BK215LocalClient("127.0.0.1", server.port, on_telemetry=received.append)
+    client.start()
+    try:
+        await _wait_for(lambda: received)
+    finally:
+        await client.async_stop()
+
+    assert received[0] == {"t211": 50, "t33": 97, "t536": 43.0}
+
+
+async def test_set_register_succeeds_on_ack(server: MockBK215Server):
+    """A write returns True when the device acks the field with 0."""
+    client = BK215LocalClient("127.0.0.1", server.port)
+    client.start()
+    try:
+        await _wait_for(lambda: client.connected)
+        result = await client.set_register("t598", 1)
+    finally:
+        await client.async_stop()
+
+    assert result is True
+    assert server.received == [{"code": protocol.CODE_SET, "data": {"t598": 1}}]
+
+
+async def test_set_register_fails_on_negative_ack(server: MockBK215Server):
+    """A non-zero ack value is reported as failure."""
+    server.ack_value = 1
+    client = BK215LocalClient("127.0.0.1", server.port)
+    client.start()
+    try:
+        await _wait_for(lambda: client.connected)
+        result = await client.set_register("t598", 1, timeout=1.0)
+    finally:
+        await client.async_stop()
+
+    assert result is False
+
+
+async def test_set_register_fails_when_disconnected(server: MockBK215Server):
+    """Writing before a connection exists returns False, not an exception."""
+    client = BK215LocalClient("127.0.0.1", server.port)
+    # never started
+    assert await client.set_register("t598", 1) is False
+
+
+async def test_reconnects_after_drop(server: MockBK215Server):
+    """The client re-dials after the server closes the connection."""
+    client = BK215LocalClient("127.0.0.1", server.port)
+    # speed the test up: shorten the reconnect backoff
+    import custom_components.sunlit.local.tcp_client as mod
+
+    original = mod.RECONNECT_DELAY
+    mod.RECONNECT_DELAY = 0.05
+    client.start()
+    try:
+        await _wait_for(lambda: server.connections >= 1)
+        await client._close_connection()  # simulate a drop
+        await _wait_for(lambda: server.connections >= 2, timeout=3.0)
+    finally:
+        mod.RECONNECT_DELAY = original
+        await client.async_stop()
+
+    assert server.connections >= 2
+
+
+async def test_state_change_callback(server: MockBK215Server):
+    """on_state_change fires True on connect and False on stop."""
+    states: list[bool] = []
+    client = BK215LocalClient("127.0.0.1", server.port, on_state_change=states.append)
+    client.start()
+    try:
+        await _wait_for(lambda: client.connected)
+    finally:
+        await client.async_stop()
+
+    assert states[0] is True
+    assert states[-1] is False
+
+
+async def _wait_for(predicate, timeout: float = 2.0) -> None:
+    """Poll ``predicate`` until truthy or raise on timeout."""
+    async with asyncio.timeout(timeout):
+        while not predicate():
+            await asyncio.sleep(0.01)

--- a/tests/test_local_tcp_client.py
+++ b/tests/test_local_tcp_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 
 import pytest
@@ -70,6 +71,8 @@ class MockBK215Server:
             pass
         finally:
             writer.close()
+            with contextlib.suppress(ConnectionError, OSError):
+                await writer.wait_closed()
 
 
 @pytest.fixture
@@ -149,6 +152,30 @@ async def test_reconnects_after_drop(server: MockBK215Server):
         await client.async_stop()
 
     assert server.connections >= 2
+
+
+async def test_client_survives_raising_telemetry_callback(server: MockBK215Server):
+    """A buggy on_telemetry must not terminate the listen task."""
+    server.queue_telemetry(0x6052, {"t211": 50})
+    server.queue_telemetry(0x6052, {"t33": 42})
+
+    received: list[dict] = []
+
+    def callback(decoded: dict) -> None:
+        received.append(decoded)
+        if len(received) == 1:
+            raise RuntimeError("boom")
+
+    client = BK215LocalClient("127.0.0.1", server.port, on_telemetry=callback)
+    client.start()
+    try:
+        await _wait_for(lambda: len(received) >= 2)
+    finally:
+        await client.async_stop()
+
+    # Two messages were delivered despite the first callback raising.
+    assert {"t211": 50} in received
+    assert {"t33": 42} in received
 
 
 async def test_state_change_callback(server: MockBK215Server):


### PR DESCRIPTION
## Summary

Foundation slice for #179 — the opt-in local-mode (TCP) channel for the BK215
battery. **No Home Assistant wiring yet**: this PR adds two HA-agnostic
modules that handle the protocol mechanics, so the next slice (host capture
from zeroconf, local-channel manager) sits on a verified base.

Clean-room reimplementation from `docs/local-protocol.md` (PR #178). The
upstream `SunEnergyXT/SunEnergyXT-BK` plugin was a behavioural reference only
— it ships without a LICENSE file, so no code was copied.

## What's in this slice

- **`custom_components/sunlit/local/protocol.py`**
  - Message codes: `0x6056` set / `0x6057` ack / `0x6052·0x6055·0x6060` telemetry.
  - Register decode table for every `tNNN` in the protocol doc, with the
    documented scalings (raw, ×0.1, ×0.01, ×0.001, −273, bitfield):
    system/module SOC, MPPT V/I pairs, PV powers, energies, cell temps,
    plus the `t586` heater bitfield split.
  - `decode_telemetry()` drops the `0xFFFFFFFF` unset sentinel and unknown keys.
  - `iter_messages()` splits newline-delimited frames, returning any trailing
    partial line as a remainder; filters blank lines, `0xAA` keepalive bytes,
    and concatenated-object junk.
  - `build_set_payload()` emits the minimal one-field-only set envelope.

- **`custom_components/sunlit/local/tcp_client.py`**
  - `BK215LocalClient`: persistent asyncio connection, callback-driven
    telemetry delivery, 60 s heartbeat-via-read-timeout, 5 s reconnect backoff.
  - `set_register()` awaits the matching `0x6057` ack with a 2 s timeout.
  - Deliberately HA-agnostic so it tests against a plain socket.

- **Tests** — 16 passing. The TCP suite spins up a real loopback mock BK215
  server and exercises telemetry decode, set-ack success/failure paths,
  drop-and-reconnect, and state callbacks.

## What's deliberately not here

- No `config_flow` changes — capturing the zeroconf host comes next.
- No new entity platforms — local will feed the **existing** entities via
  `device_coordinator.async_set_updated_data(...)` once wired up.
- No control entities (`number`/`switch` for SOC/power setpoints) — deferred
  to a later slice; the existing #160 local-mode switch already controls the
  gate.

## Design decisions

- **Auto-gate, not separate opt-in.** When the next slices land, local will
  activate iff `support_local_mode && local_mode_enabled && host_known`. The
  #160 switch becomes the de-facto on/off; no extra UI toggle.
- **Telemetry-first.** Local refreshes the same entities faster; cloud stays
  as the floor if the connection drops.
- **HA owns the single TCP client** (the device likely accepts only one;
  the phone app gets locked out while HA is connected — accepted trade-off).

## Test plan

```bash
.venv/bin/python -m pytest tests/test_local_protocol.py tests/test_local_tcp_client.py --asyncio-mode=auto
# 16 passed
```

Part of #163 (epic). Builds on #178 (protocol doc) and complements #160
(cloud local-mode switch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced local-mode TCP connectivity for BK215 batteries, enabling direct network communication when accessible on your LAN with automatic reconnection and status notifications.

* **Tests**
  * Added comprehensive unit and integration tests validating protocol implementation, telemetry reception and decoding, connection state management, and device write operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/ha-sunlit/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->