### PR TITLE
feat(local): persist BK215 LAN info from zeroconf for local channel

### DIFF
--- a/custom_components/sunlit/config_flow.py
+++ b/custom_components/sunlit/config_flow.py
@@ -24,6 +24,7 @@ from .api_client import SunlitApiClient, SunlitAuthError, SunlitConnectionError
 from .const import (
     API_BASE_URL,
     CONF_ACCESS_TOKEN,
+    CONF_BATTERIES,
     CONF_EMAIL,
     CONF_FAMILIES,
     CONF_PASSWORD,
@@ -44,8 +45,42 @@ from .const import (
     OPT_SOC_THRESHOLD_HIGH,
     OPT_SOC_THRESHOLD_LOW,
 )
+from .local.protocol import DEFAULT_PORT as LOCAL_TCP_PORT
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _parse_battery_discovery(
+    discovery_info: ZeroconfServiceInfo,
+) -> dict[str, Any] | None:
+    """Extract battery LAN info from a ``hp-bk215`` zeroconf advertisement.
+
+    Returns a dict with serial/host/port and optional firmware/hardware
+    versions, or ``None`` if the advertisement lacks the required fields.
+
+    The TXT ``port`` property carries the TCP control port (observed 8000);
+    the mDNS service port (``discovery_info.port``) advertises the device's
+    ``_http`` port and is not what the local-mode channel uses.
+    """
+    properties = discovery_info.properties or {}
+    serial = properties.get("id")
+    if not serial:
+        return None
+    host = discovery_info.host
+    if not host:
+        return None
+    port_raw = properties.get("port")
+    try:
+        port = int(port_raw) if port_raw is not None else LOCAL_TCP_PORT
+    except (TypeError, ValueError):
+        port = LOCAL_TCP_PORT
+    return {
+        "serial": serial,
+        "host": host,
+        "port": port,
+        "sw_version": properties.get("fw_ver"),
+        "hw_version": properties.get("model"),
+    }
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -68,41 +103,68 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.access_token: str | None = None
         self.families: dict[str, Any] = {}
         self.available_families: list[dict[str, Any]] = []
-        self._discovered_serial: str | None = None
+        self._discovered_battery: dict[str, Any] | None = None
 
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> FlowResult:
         """Handle a battery discovered via mDNS/zeroconf.
 
-        The BK215 (Highpower) advertises itself on the local network as
-        ``hp-bk215*`` over ``_http._tcp.local.``. This integration is
-        cloud-polling, so discovery only acts as an onboarding trigger:
-        we surface the device and then funnel the user into the normal
-        cloud credential flow. The discovered serial is recorded so a
-        future opt-in local-polling mode can reuse it.
+        The BK215 (Highpower) advertises itself as ``hp-bk215*`` over
+        ``_http._tcp.local.``. Two roles for this step:
+
+        - **Onboarding** — when no cloud entry exists yet, surface the device
+          and funnel the user into the normal credential flow; the captured
+          LAN info is stamped onto the entry as it's created.
+        - **Address refresh** — when an entry already exists, merge the
+          (possibly changed) host/port into ``entry.data[CONF_BATTERIES]``
+          so the opt-in local-mode channel can use it. DHCP can rotate the
+          IP, so we accept rediscoveries instead of ignoring them.
         """
-        properties = discovery_info.properties
-        self._discovered_serial = properties.get("id")
+        battery = _parse_battery_discovery(discovery_info)
+        if battery is None:
+            return self.async_abort(reason="invalid_discovery")
+        self._discovered_battery = battery
 
         # Dedupe concurrent discovery flows for the same battery.
-        await self.async_set_unique_id(self._discovered_serial or DOMAIN)
+        await self.async_set_unique_id(battery["serial"])
         self._abort_if_unique_id_configured()
 
-        # Single-entry integration: one cloud account covers every device,
-        # so once anything is set up there is nothing more to discover.
-        if self._async_current_entries():
+        # If a cloud entry is already set up, this advertisement is just a
+        # LAN refresh: merge the LAN info and reload only on real changes.
+        existing = self._existing_entry()
+        if existing is not None:
+            if self._merge_battery_into_entry(existing, battery):
+                self.hass.async_create_task(
+                    self.hass.config_entries.async_reload(existing.entry_id)
+                )
             return self.async_abort(reason="already_configured")
 
         self.context["title_placeholders"] = {
-            "name": (
-                f"Sunlit BK215 ({self._discovered_serial})"
-                if self._discovered_serial
-                else "Sunlit BK215"
-            )
+            "name": f"Sunlit BK215 ({battery['serial']})"
         }
 
         return await self.async_step_zeroconf_confirm()
+
+    def _existing_entry(self) -> config_entries.ConfigEntry | None:
+        """Return the integration's single cloud entry, or None."""
+        entries = self._async_current_entries()
+        return entries[0] if entries else None
+
+    def _merge_battery_into_entry(
+        self,
+        entry: config_entries.ConfigEntry,
+        battery: dict[str, Any],
+    ) -> bool:
+        """Merge a discovered battery into ``entry.data``; return True if changed."""
+        current = entry.data.get(CONF_BATTERIES, {}) or {}
+        if current.get(battery["serial"]) == battery:
+            return False
+        updated = {**current, battery["serial"]: battery}
+        self.hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_BATTERIES: updated}
+        )
+        return True
 
     async def async_step_zeroconf_confirm(
         self, user_input: dict[str, Any] | None = None
@@ -111,11 +173,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             return await self.async_step_user()
 
+        serial = (
+            self._discovered_battery["serial"]
+            if self._discovered_battery is not None
+            else "unknown"
+        )
         return self.async_show_form(
             step_id="zeroconf_confirm",
-            description_placeholders={
-                "serial_number": self._discovered_serial or "unknown"
-            },
+            description_placeholders={"serial_number": serial},
         )
 
     async def async_step_user(
@@ -217,12 +282,22 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 family_names = [f["name"] for f in self.families.values()]
                 title = f"Sunlit ({', '.join(family_names)})"
 
+                # Stamp any zeroconf-discovered battery onto the new entry so
+                # the local channel can pick up the LAN address without
+                # waiting for another mDNS round.
+                batteries: dict[str, dict[str, Any]] = {}
+                if self._discovered_battery is not None:
+                    batteries[self._discovered_battery["serial"]] = (
+                        self._discovered_battery
+                    )
+
                 return self.async_create_entry(
                     title=title,
                     data={
                         CONF_EMAIL: self.email,
                         CONF_ACCESS_TOKEN: self.access_token,
                         CONF_FAMILIES: self.families,
+                        CONF_BATTERIES: batteries,
                     },
                     options=DEFAULT_OPTIONS,
                 )

--- a/custom_components/sunlit/const.py
+++ b/custom_components/sunlit/const.py
@@ -45,6 +45,10 @@ CONF_ACCESS_TOKEN = "access_token"
 CONF_FAMILIES = "families"
 CONF_FAMILY_ID = "family_id"
 CONF_FAMILY_NAME = "family_name"
+# Per-battery LAN info captured from zeroconf, keyed by serial. Consumed by
+# the opt-in local-mode (TCP) channel; absent for entries that have never
+# seen a zeroconf advertisement.
+CONF_BATTERIES = "batteries"
 
 # Options keys for SOC event management
 OPT_ENABLE_SOC_EVENTS = "enable_soc_events"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -10,24 +10,40 @@ from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from custom_components.sunlit import DOMAIN
 from custom_components.sunlit.api_client import SunlitAuthError, SunlitConnectionError
-from custom_components.sunlit.const import CONF_ACCESS_TOKEN, CONF_FAMILIES
+from custom_components.sunlit.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_BATTERIES,
+    CONF_FAMILIES,
+)
 
 
-def _zeroconf_discovery_info(serial: str = "HP-BK215-001") -> ZeroconfServiceInfo:
-    """Build a ZeroconfServiceInfo mimicking a BK215 mDNS advertisement."""
+def _zeroconf_discovery_info(
+    serial: str = "HP-BK215-001",
+    host: str = "192.168.1.50",
+    properties: dict[str, str] | None = None,
+) -> ZeroconfServiceInfo:
+    """Build a ZeroconfServiceInfo mimicking a BK215 mDNS advertisement.
+
+    The mDNS service ``port`` is the device's ``_http`` port (80); the real
+    TCP control port is advertised separately in the TXT ``port`` property
+    (observed as 8000) and is what the local-mode channel uses.
+    """
+    txt = {
+        "id": serial,
+        "port": "8000",
+        "fw_ver": "1.2.3",
+        "model": "BK215",
+    }
+    if properties is not None:
+        txt.update(properties)
     return ZeroconfServiceInfo(
-        ip_address=ip_address("192.168.1.50"),
-        ip_addresses=[ip_address("192.168.1.50")],
+        ip_address=ip_address(host),
+        ip_addresses=[ip_address(host)],
         port=80,
-        hostname="hp-bk215-001.local.",
+        hostname=f"{serial.lower()}.local.",
         type="_http._tcp.local.",
-        name="hp-bk215-001._http._tcp.local.",
-        properties={
-            "id": serial,
-            "port": "80",
-            "fw_ver": "1.2.3",
-            "model": "BK215",
-        },
+        name=f"{serial.lower()}._http._tcp.local.",
+        properties=txt,
     )
 
 
@@ -357,13 +373,25 @@ async def test_zeroconf_discovery_full_flow(
     assert result4["type"] == FlowResultType.CREATE_ENTRY
     assert result4["data"][CONF_ACCESS_TOKEN] == "test_api_key_123"
     assert len(result4["data"][CONF_FAMILIES]) == 1
+    # The discovered battery is stamped onto the new entry so the local
+    # channel can pick up its LAN address without waiting for another mDNS round.
+    batteries = result4["data"][CONF_BATTERIES]
+    assert batteries == {
+        "HP-BK215-001": {
+            "serial": "HP-BK215-001",
+            "host": "192.168.1.50",
+            "port": 8000,
+            "sw_version": "1.2.3",
+            "hw_version": "BK215",
+        }
+    }
 
 
 async def test_zeroconf_discovery_already_configured(
     hass: HomeAssistant,
     mock_config_entry,
 ):
-    """Discovery should abort when the account is already configured."""
+    """Discovery into a configured account merges LAN info, then aborts."""
     mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -374,3 +402,110 @@ async def test_zeroconf_discovery_already_configured(
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+    # First-time discovery against a pre-existing entry should populate
+    # the batteries map.
+    assert mock_config_entry.data[CONF_BATTERIES] == {
+        "HP-BK215-001": {
+            "serial": "HP-BK215-001",
+            "host": "192.168.1.50",
+            "port": 8000,
+            "sw_version": "1.2.3",
+            "hw_version": "BK215",
+        }
+    }
+
+
+async def test_zeroconf_rediscovery_updates_changed_host(
+    hass: HomeAssistant,
+    mock_config_entry,
+):
+    """A rediscovery with a new IP rewrites the entry's batteries map."""
+    mock_config_entry.add_to_hass(hass)
+
+    # First advertisement at the original address.
+    await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=_zeroconf_discovery_info(host="192.168.1.50"),
+    )
+    assert mock_config_entry.data[CONF_BATTERIES]["HP-BK215-001"]["host"] == (
+        "192.168.1.50"
+    )
+
+    # DHCP gave the battery a new lease.
+    with patch.object(hass.config_entries, "async_reload", AsyncMock()) as mock_reload:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data=_zeroconf_discovery_info(host="192.168.1.99"),
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert mock_config_entry.data[CONF_BATTERIES]["HP-BK215-001"]["host"] == (
+        "192.168.1.99"
+    )
+    # The change should trigger a reload so the local channel picks up the
+    # new address.
+    mock_reload.assert_called_once_with(mock_config_entry.entry_id)
+
+
+async def test_zeroconf_rediscovery_no_change_does_not_reload(
+    hass: HomeAssistant,
+    mock_config_entry,
+):
+    """Repeat advertisements with identical info must not reload the entry."""
+    mock_config_entry.add_to_hass(hass)
+
+    # Prime the entry with one advertisement.
+    await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=_zeroconf_discovery_info(),
+    )
+
+    # Identical re-advertisement should be a no-op.
+    with patch.object(hass.config_entries, "async_reload", AsyncMock()) as mock_reload:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data=_zeroconf_discovery_info(),
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    mock_reload.assert_not_called()
+
+
+async def test_zeroconf_falls_back_to_default_port_when_txt_port_missing(
+    hass: HomeAssistant,
+    mock_config_entry,
+):
+    """A TXT advertisement without a usable port falls back to 8000."""
+    mock_config_entry.add_to_hass(hass)
+
+    discovery = _zeroconf_discovery_info()
+    discovery.properties.pop("port")
+
+    await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=discovery,
+    )
+
+    assert mock_config_entry.data[CONF_BATTERIES]["HP-BK215-001"]["port"] == 8000
+
+
+async def test_zeroconf_aborts_when_serial_missing(hass: HomeAssistant):
+    """A TXT record with no ``id`` (serial) is rejected as invalid."""
+    discovery = _zeroconf_discovery_info()
+    discovery.properties.pop("id")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=discovery,
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "invalid_discovery"


### PR DESCRIPTION
## Summary

Second slice of #179. Captures the BK215's host and TCP control port from
its mDNS advertisement and persists them on the config entry, keyed by
serial. The (future) local-mode manager can then find the battery without
waiting on the cloud — `device.ip` is null/unreliable and zeroconf is the
only reliable source.

Builds on #202 (the protocol + TCP client foundation).

## What changes

**`config_flow.py`**
- New `_parse_battery_discovery()` helper pulls serial/host/sw/hw from the
  TXT properties and resolves the control port. Critical detail: the TXT
  `port` property carries the **TCP control port (8000)**, not the mDNS
  service port (80, which is the device's `_http` port). When the TXT
  value is missing or unparseable, falls back to `LOCAL_TCP_PORT` from the
  protocol module (also 8000).
- `async_step_zeroconf` now handles two roles cleanly:
  - **Onboarding** — fresh install: info gets stamped onto the entry as
    `select_families` creates it.
  - **Address refresh** — existing entry: merge into the batteries map,
    reload **only on real change** (avoids restart loops on every mDNS
    refresh). DHCP routinely rotates the IP, so accepting rediscoveries
    is required.
- New `entry.data[CONF_BATTERIES]` map, keyed by serial. Older entries
  read it with `.get()` so no migration is needed.
- Discovery with no serial is rejected with `reason: invalid_discovery`
  rather than crashing later.

**`const.py`** — adds `CONF_BATTERIES = "batteries"`.

## Tests

- The zeroconf fixture now advertises **port `"8000"`** in TXT (the
  realistic control-port value; the previous `"80"` was the `_http` port,
  never what the local channel uses).
- Extended the full zeroconf flow test to assert the new entry holds the
  battery info.
- New tests:
  - rediscovery with a new IP merges into the entry and triggers a reload,
  - rediscovery with no change does **not** reload,
  - missing TXT port falls back to 8000,
  - serial-less advertisement aborts as `invalid_discovery`.

Full suite: 257 passed, no regressions.

## Out of scope (next slice)

- The local-channel **manager** that watches `local_mode_enabled` + this
  batteries map and starts/stops the TCP client.
- Wiring the decoded telemetry into the device coordinator via
  `async_set_updated_data`.
- Control entities (numbers/switches).

Part of #163 (epic). Relates to #160, #157.