### PR TITLE
feat(local): wire BK215 TCP channel into the device coordinator

### DIFF
--- a/custom_components/sunlit/__init__.py
+++ b/custom_components/sunlit/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .api_client import SunlitApiClient
 from .const import (
     CONF_ACCESS_TOKEN,
+    CONF_BATTERIES,
     CONF_FAMILIES,
     DEFAULT_OPTIONS,
     DOMAIN,
@@ -30,6 +31,7 @@ from .coordinators import (
     SunlitStrategyHistoryCoordinator,
 )
 from .event_manager import SunlitEventManager
+from .local.manager import LocalChannelManager
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -156,11 +158,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "mppt": mppt_coordinator,
         }
 
+    # Spin up the opt-in local-mode TCP channel. The manager watches each
+    # family's device coordinator and, for batteries with local mode enabled
+    # and a host known (from zeroconf), maintains a persistent TCP client
+    # that pushes telemetry into the same coordinator the cloud poll feeds.
+    device_coordinators = {
+        family_id: coord_set["device"] for family_id, coord_set in coordinators.items()
+    }
+    local_manager = LocalChannelManager(
+        hass,
+        device_coordinators=device_coordinators,
+        batteries=entry.data.get(CONF_BATTERIES, {}),
+    )
+    local_manager.start()
+
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
         "coordinators": coordinators,
         "event_managers": event_managers,
         "api_client": api_client,
+        "local_manager": local_manager,
     }
 
     # Add update listener for options changes
@@ -180,6 +197,9 @@ async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
+        entry_data = hass.data[DOMAIN].pop(entry.entry_id, {})
+        local_manager = entry_data.get("local_manager")
+        if local_manager is not None:
+            await local_manager.async_stop()
 
     return unload_ok

--- a/custom_components/sunlit/local/manager.py
+++ b/custom_components/sunlit/local/manager.py
@@ -1,0 +1,181 @@
+"""Manage BK215 local-mode TCP clients gated by the cloud's local-mode flag.
+
+For each family's device coordinator, the manager watches every battery
+that advertises ``supportLocalMode`` and the live ``localModeEnabled`` flag.
+When both are true and the battery's LAN address is known (captured into
+``entry.data[CONF_BATTERIES]`` by the zeroconf step), a persistent TCP
+client is started; telemetry pushes are translated and merged into the
+device coordinator so existing sensors refresh faster than the 30 s cloud
+poll.
+
+The cloud poll stays as the floor: a dropped TCP connection or a routine
+cloud refresh both still keep entities populated.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant, callback
+
+from ..const import DEVICE_TYPE_BATTERY
+from .tcp_client import BK215LocalClient
+from .translate import translate_to_device_keys
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class LocalChannelManager:
+    """Reconcile BK215 local TCP clients with cloud-reported state."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        device_coordinators: dict[str, Any],
+        batteries: dict[str, dict[str, Any]],
+        *,
+        client_factory: Callable[..., BK215LocalClient] = BK215LocalClient,
+    ) -> None:
+        """Initialize the manager.
+
+        Args:
+            hass: HomeAssistant instance for scheduling teardown tasks.
+            device_coordinators: ``family_id`` -> SunlitDeviceCoordinator.
+            batteries: ``serial`` -> ``{host, port, sw_version, hw_version}``
+                from ``entry.data[CONF_BATTERIES]``.
+            client_factory: TCP client constructor (overridable for tests).
+        """
+        self._hass = hass
+        self._device_coordinators = device_coordinators
+        self._batteries = batteries
+        self._client_factory = client_factory
+        self._clients: dict[str, BK215LocalClient] = {}
+        self._unsubscribers: list[Callable[[], None]] = []
+
+    def start(self) -> None:
+        """Subscribe to every coordinator and reconcile against current state."""
+        for coordinator in self._device_coordinators.values():
+            unsub = coordinator.async_add_listener(self._make_listener(coordinator))
+            self._unsubscribers.append(unsub)
+            # Reconcile once now so we don't wait for the next coordinator tick.
+            self._on_coordinator_update(coordinator)
+
+    async def async_stop(self) -> None:
+        """Detach from coordinators and stop every running client."""
+        for unsub in self._unsubscribers:
+            unsub()
+        self._unsubscribers.clear()
+        for client in list(self._clients.values()):
+            await client.async_stop()
+        self._clients.clear()
+
+    def _make_listener(self, coordinator: Any) -> Callable[[], None]:
+        """Bind a coordinator into a no-arg listener callback."""
+
+        @callback
+        def listener() -> None:
+            self._on_coordinator_update(coordinator)
+
+        return listener
+
+    @callback
+    def _on_coordinator_update(self, coordinator: Any) -> None:
+        """Reconcile every battery in this coordinator's data."""
+        if coordinator.data is None:
+            return
+        devices = coordinator.data.get("devices", {})
+        for device_id, device_data in devices.items():
+            if device_data.get("deviceType") != DEVICE_TYPE_BATTERY:
+                continue
+            self._reconcile_battery(coordinator, device_id, device_data)
+
+    def _reconcile_battery(
+        self,
+        coordinator: Any,
+        device_id: str,
+        device_data: dict[str, Any],
+    ) -> None:
+        """Start or stop the local client for one battery to match state."""
+        cloud_device = (
+            coordinator.devices.get(device_id) if coordinator.devices else None
+        )
+        serial = cloud_device.get("deviceSn") if cloud_device else None
+        if not serial:
+            return
+
+        wants_local = bool(
+            device_data.get("support_local_mode")
+            and device_data.get("local_mode_enabled")
+        )
+        battery_info = self._batteries.get(serial)
+        current_client = self._clients.get(serial)
+
+        if wants_local and battery_info and current_client is None:
+            self._start_client(serial, battery_info, coordinator, device_id)
+        elif (not wants_local or not battery_info) and current_client is not None:
+            self._stop_client(serial)
+
+    def _start_client(
+        self,
+        serial: str,
+        battery_info: dict[str, Any],
+        coordinator: Any,
+        device_id: str,
+    ) -> None:
+        host = battery_info["host"]
+        port = battery_info["port"]
+        _LOGGER.info(
+            "Starting local channel for battery %s at %s:%s", serial, host, port
+        )
+        client = self._client_factory(
+            host=host,
+            port=port,
+            on_telemetry=self._make_telemetry_callback(coordinator, device_id),
+            name=serial,
+        )
+        client.start()
+        self._clients[serial] = client
+
+    def _stop_client(self, serial: str) -> None:
+        client = self._clients.pop(serial, None)
+        if client is None:
+            return
+        _LOGGER.info("Stopping local channel for battery %s", serial)
+        # Listeners run in a sync context; defer the async teardown.
+        self._hass.async_create_task(client.async_stop())
+
+    def _make_telemetry_callback(
+        self, coordinator: Any, device_id: str
+    ) -> Callable[[dict[str, Any]], None]:
+        """Bind coordinator+device into a telemetry-handling callable."""
+
+        def on_telemetry(decoded: dict[str, Any]) -> None:
+            self._push_telemetry(coordinator, device_id, decoded)
+
+        return on_telemetry
+
+    @callback
+    def _push_telemetry(
+        self,
+        coordinator: Any,
+        device_id: str,
+        decoded: dict[str, Any],
+    ) -> None:
+        """Merge translated local registers into the coordinator's data."""
+        translated = translate_to_device_keys(decoded)
+        if not translated:
+            return
+        current_data = coordinator.data
+        if not current_data:
+            return
+        devices = current_data.get("devices", {})
+        if device_id not in devices:
+            return
+        merged = {**devices[device_id], **translated}
+        new_data = {
+            **current_data,
+            "devices": {**devices, device_id: merged},
+        }
+        coordinator.async_set_updated_data(new_data)

--- a/custom_components/sunlit/local/translate.py
+++ b/custom_components/sunlit/local/translate.py
@@ -1,0 +1,89 @@
+"""Translate decoded BK215 local-protocol registers into cloud entity keys.
+
+The local TCP channel pushes register-keyed maps like
+``{"t211": 50, "t536": 43.0, ...}``. The integration's existing sensors
+read fields like ``battery_level`` and ``batteryMppt1InVol`` from each
+battery's entry in the device-coordinator data dict.
+
+This module is the bridge: a pure function that converts a decoded local
+map into a partial cloud-key map suitable for merging into one battery
+device's data, so existing entities just refresh faster when local mode
+is active. Anything not in the mapping is silently dropped.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# tNNN -> tuple of cloud entity keys it should populate. A few local
+# registers map to multiple cloud keys because the cloud surfaces the
+# same value under more than one name (e.g. system SOC).
+_REGISTER_TO_CLOUD_KEYS: dict[str, tuple[str, ...]] = {
+    # System aggregates (head + all modules)
+    "t211": ("battery_level", "batterySoc"),
+    "t33": ("input_power_total",),
+    "t34": ("output_power_total",),
+    # Head unit MPPTs (1 and 2)
+    "t536": ("batteryMppt1InVol",),
+    "t537": ("batteryMppt1InCur",),
+    "t544": ("batteryMppt2InVol",),
+    "t545": ("batteryMppt2InCur",),
+    "t50": ("batteryMppt1InPower",),
+    "t62": ("batteryMppt2InPower",),
+    # Module 1
+    "t593": ("battery1Soc",),
+    "t552": ("battery1Mppt1InVol",),
+    "t553": ("battery1Mppt1InCur",),
+    "t63": ("battery1Mppt1InPower",),
+    # Module 2
+    "t594": ("battery2Soc",),
+    "t560": ("battery2Mppt1InVol",),
+    "t561": ("battery2Mppt1InCur",),
+    "t64": ("battery2Mppt1InPower",),
+    # Module 3
+    "t595": ("battery3Soc",),
+    "t568": ("battery3Mppt1InVol",),
+    "t569": ("battery3Mppt1InCur",),
+    "t65": ("battery3Mppt1InPower",),
+    # Module 4
+    "t1001": ("battery4Soc",),
+    "t969": ("battery4Mppt1InVol",),
+    "t970": ("battery4Mppt1InCur",),
+    "t812": ("battery4Mppt1InPower",),
+    # Module 5
+    "t1002": ("battery5Soc",),
+    "t977": ("battery5Mppt1InVol",),
+    "t978": ("battery5Mppt1InCur",),
+    "t813": ("battery5Mppt1InPower",),
+    # Module 6
+    "t1003": ("battery6Soc",),
+    "t985": ("battery6Mppt1InVol",),
+    "t986": ("battery6Mppt1InCur",),
+    "t814": ("battery6Mppt1InPower",),
+    # Module 7
+    "t1004": ("battery7Soc",),
+    "t993": ("battery7Mppt1InVol",),
+    "t994": ("battery7Mppt1InCur",),
+    "t815": ("battery7Mppt1InPower",),
+}
+
+
+def translate_to_device_keys(decoded: dict[str, Any]) -> dict[str, Any]:
+    """Convert decoded local registers into cloud entity keys.
+
+    ``decoded`` is the output of :func:`protocol.decode_telemetry` — a map
+    of ``tNNN`` register names to already-scaled values. The returned dict
+    is a partial cloud-key map to merge into one battery device's slot in
+    ``device_coordinator.data["devices"][device_id]``.
+
+    Registers without a known cloud mapping (e.g. ``t592`` head real SOC,
+    ``t49`` daily generation, ``t586`` heater bitfield) are dropped. They
+    can be surfaced later as new local-only entities; until then the cloud
+    poll continues to be the source of truth for derived fields like
+    ``stored_energy``, which won't refresh from local pushes alone.
+    """
+    result: dict[str, Any] = {}
+    for register, value in decoded.items():
+        for cloud_key in _REGISTER_TO_CLOUD_KEYS.get(register, ()):
+            result[cloud_key] = value
+    return result

--- a/tests/test_local_manager.py
+++ b/tests/test_local_manager.py
@@ -1,0 +1,265 @@
+"""Tests for the BK215 local-channel manager.
+
+The manager's job is reconciliation: starting/stopping a TCP client per
+battery to match the cloud-reported ``local_mode_enabled`` state and
+pushing translated telemetry into the device coordinator. These tests use
+a fake coordinator and a fake client to exercise that reconciliation
+without touching real sockets — the real TCP client is covered by
+test_local_tcp_client.py against a loopback server.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, ClassVar
+
+import pytest
+
+from custom_components.sunlit.local.manager import LocalChannelManager
+
+BATTERY_DEVICE_ID = "1001"
+BATTERY_SERIAL = "HP-BK215-001"
+BATTERY_HOST = "192.168.1.50"
+BATTERY_PORT = 8000
+
+
+class FakeCoordinator:
+    """Stand-in for SunlitDeviceCoordinator with the bits the manager touches."""
+
+    def __init__(self) -> None:
+        self.data: dict[str, Any] | None = None
+        self.devices: dict[str, dict[str, Any]] = {}
+        self._listeners: list[Callable[[], None]] = []
+
+    def async_add_listener(
+        self, update_callback: Callable[[], None]
+    ) -> Callable[[], None]:
+        self._listeners.append(update_callback)
+
+        def _unsub() -> None:
+            if update_callback in self._listeners:
+                self._listeners.remove(update_callback)
+
+        return _unsub
+
+    def async_set_updated_data(self, data: dict[str, Any]) -> None:
+        self.data = data
+        for callback in list(self._listeners):
+            callback()
+
+    # Test helpers ---------------------------------------------------------
+
+    def seed_battery(
+        self,
+        *,
+        device_id: str = BATTERY_DEVICE_ID,
+        serial: str = BATTERY_SERIAL,
+        support_local_mode: bool = True,
+        local_mode_enabled: bool = True,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        """Push an initial coordinator state with one battery present."""
+        self.devices = {device_id: {"deviceId": device_id, "deviceSn": serial}}
+        device_data: dict[str, Any] = {
+            "deviceType": "ENERGY_STORAGE_BATTERY",
+            "support_local_mode": support_local_mode,
+            "local_mode_enabled": local_mode_enabled,
+        }
+        if extra:
+            device_data.update(extra)
+        self.async_set_updated_data({"devices": {device_id: device_data}})
+
+
+class FakeClient:
+    """TCP client stand-in capturing start/stop and exposing the callback."""
+
+    instances: ClassVar[list[FakeClient]] = []
+
+    def __init__(
+        self,
+        *,
+        host: str,
+        port: int,
+        on_telemetry: Callable[[dict[str, Any]], None] | None = None,
+        on_state_change: Callable[[bool], None] | None = None,
+        name: str | None = None,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.on_telemetry = on_telemetry
+        self.on_state_change = on_state_change
+        self.name = name
+        self.started = False
+        self.stopped = False
+        FakeClient.instances.append(self)
+
+    def start(self) -> None:
+        self.started = True
+
+    async def async_stop(self) -> None:
+        self.stopped = True
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_clients():
+    FakeClient.instances.clear()
+    yield
+    FakeClient.instances.clear()
+
+
+@pytest.fixture
+def batteries() -> dict[str, dict[str, Any]]:
+    """A populated batteries map keyed by serial."""
+    return {
+        BATTERY_SERIAL: {
+            "serial": BATTERY_SERIAL,
+            "host": BATTERY_HOST,
+            "port": BATTERY_PORT,
+            "sw_version": "1.2.3",
+            "hw_version": "BK215",
+        }
+    }
+
+
+def _make_manager(
+    hass, coordinator: FakeCoordinator, batteries: dict[str, dict[str, Any]]
+) -> LocalChannelManager:
+    return LocalChannelManager(
+        hass,
+        device_coordinators={"34038": coordinator},
+        batteries=batteries,
+        client_factory=FakeClient,
+    )
+
+
+async def test_starts_client_when_local_mode_enabled(hass, batteries):
+    """A battery with support+enabled+host gets a client started."""
+    coordinator = FakeCoordinator()
+    coordinator.seed_battery()
+    manager = _make_manager(hass, coordinator, batteries)
+
+    manager.start()
+
+    assert len(FakeClient.instances) == 1
+    client = FakeClient.instances[0]
+    assert client.host == BATTERY_HOST
+    assert client.port == BATTERY_PORT
+    assert client.name == BATTERY_SERIAL
+    assert client.started is True
+
+    await manager.async_stop()
+
+
+async def test_skips_battery_with_unknown_host(hass):
+    """A battery whose serial isn't in the batteries map is left alone."""
+    coordinator = FakeCoordinator()
+    coordinator.seed_battery()
+    # batteries map is empty -> no known host
+    manager = _make_manager(hass, coordinator, batteries={})
+
+    manager.start()
+
+    assert FakeClient.instances == []
+    await manager.async_stop()
+
+
+async def test_skips_battery_when_local_mode_disabled(hass, batteries):
+    """When local_mode_enabled is False, no client is started."""
+    coordinator = FakeCoordinator()
+    coordinator.seed_battery(local_mode_enabled=False)
+    manager = _make_manager(hass, coordinator, batteries)
+
+    manager.start()
+
+    assert FakeClient.instances == []
+    await manager.async_stop()
+
+
+async def test_starts_when_flag_flips_on_after_setup(hass, batteries):
+    """A battery that turns local mode on at runtime gets a client started."""
+    coordinator = FakeCoordinator()
+    coordinator.seed_battery(local_mode_enabled=False)
+    manager = _make_manager(hass, coordinator, batteries)
+    manager.start()
+    assert FakeClient.instances == []
+
+    # Flip the flag on via a coordinator update (as the cloud poll would).
+    coordinator.seed_battery(local_mode_enabled=True)
+
+    assert len(FakeClient.instances) == 1
+    assert FakeClient.instances[0].started is True
+
+    await manager.async_stop()
+
+
+async def test_stops_client_when_local_mode_flips_off(hass, batteries):
+    """A previously running client is torn down when the flag flips off."""
+    coordinator = FakeCoordinator()
+    coordinator.seed_battery()
+    manager = _make_manager(hass, coordinator, batteries)
+    manager.start()
+    client = FakeClient.instances[0]
+    assert client.started
+
+    coordinator.seed_battery(local_mode_enabled=False)
+    # Stopping happens via hass.async_create_task; let the loop run.
+    await hass.async_block_till_done()
+
+    assert client.stopped is True
+    await manager.async_stop()
+
+
+async def test_telemetry_merges_into_coordinator(hass, batteries):
+    """A telemetry push is translated and merged onto the battery device."""
+    coordinator = FakeCoordinator()
+    coordinator.seed_battery(extra={"battery_level": 30, "input_power_total": 0})
+    manager = _make_manager(hass, coordinator, batteries)
+    manager.start()
+    client = FakeClient.instances[0]
+
+    # Simulate the TCP client delivering decoded telemetry.
+    client.on_telemetry({"t211": 73, "t33": 1200, "t536": 43.0})
+
+    device = coordinator.data["devices"][BATTERY_DEVICE_ID]
+    assert device["battery_level"] == 73
+    assert device["batterySoc"] == 73
+    assert device["input_power_total"] == 1200
+    assert device["batteryMppt1InVol"] == 43.0
+    # Unrelated cloud fields are preserved.
+    assert device["deviceType"] == "ENERGY_STORAGE_BATTERY"
+
+    await manager.async_stop()
+
+
+async def test_telemetry_for_unknown_device_is_ignored(hass, batteries):
+    """A push for a device_id not in the coordinator is silently dropped."""
+    coordinator = FakeCoordinator()
+    coordinator.seed_battery()
+    manager = _make_manager(hass, coordinator, batteries)
+    manager.start()
+    client = FakeClient.instances[0]
+
+    # Remove the battery from the coordinator between bind and push.
+    coordinator.async_set_updated_data({"devices": {}})
+
+    # This should not raise even though the device is gone.
+    client.on_telemetry({"t211": 99})
+
+    assert coordinator.data == {"devices": {}}
+    await manager.async_stop()
+
+
+async def test_async_stop_tears_down_all_clients(hass, batteries):
+    """async_stop closes every running client and detaches listeners."""
+    coordinator = FakeCoordinator()
+    coordinator.seed_battery()
+    manager = _make_manager(hass, coordinator, batteries)
+    manager.start()
+    client = FakeClient.instances[0]
+
+    await manager.async_stop()
+
+    assert client.stopped is True
+    # A subsequent coordinator update must not resurrect anything.
+    coordinator.seed_battery()
+    assert len(FakeClient.instances) == 1

--- a/tests/test_local_translate.py
+++ b/tests/test_local_translate.py
@@ -1,0 +1,97 @@
+"""Tests for the local-register -> cloud-entity-key translation."""
+
+from __future__ import annotations
+
+from custom_components.sunlit.local.translate import translate_to_device_keys
+
+
+def test_system_soc_populates_both_cloud_keys():
+    """t211 fills both battery_level and batterySoc (the cloud carries both)."""
+    result = translate_to_device_keys({"t211": 73})
+    assert result == {"battery_level": 73, "batterySoc": 73}
+
+
+def test_total_power_registers():
+    """t33 and t34 map to the totals used by the family-level sensors."""
+    result = translate_to_device_keys({"t33": 1200, "t34": 850})
+    assert result == {"input_power_total": 1200, "output_power_total": 850}
+
+
+def test_head_mppt_voltage_current_power():
+    """Head MPPT 1 and 2 each map V/I/Power to the cloud's batteryMpptN* keys."""
+    decoded = {
+        "t536": 43.0,
+        "t537": 2.1,
+        "t544": 42.8,
+        "t545": 1.9,
+        "t50": 90,
+        "t62": 81,
+    }
+    result = translate_to_device_keys(decoded)
+    assert result == {
+        "batteryMppt1InVol": 43.0,
+        "batteryMppt1InCur": 2.1,
+        "batteryMppt2InVol": 42.8,
+        "batteryMppt2InCur": 1.9,
+        "batteryMppt1InPower": 90,
+        "batteryMppt2InPower": 81,
+    }
+
+
+def test_all_seven_module_socs_map():
+    """Modules 1..7 SOCs cover the t593-t595 and t1001-t1004 slot ranges."""
+    decoded = {
+        "t593": 80,
+        "t594": 81,
+        "t595": 82,
+        "t1001": 83,
+        "t1002": 84,
+        "t1003": 85,
+        "t1004": 86,
+    }
+    result = translate_to_device_keys(decoded)
+    assert result == {
+        "battery1Soc": 80,
+        "battery2Soc": 81,
+        "battery3Soc": 82,
+        "battery4Soc": 83,
+        "battery5Soc": 84,
+        "battery6Soc": 85,
+        "battery7Soc": 86,
+    }
+
+
+def test_module_mppt_voltage_current_power():
+    """Each module's MPPT V/I/Power maps to batteryNMppt1* cloud keys."""
+    decoded = {
+        # Module 1
+        "t552": 41.0,
+        "t553": 1.5,
+        "t63": 62,
+        # Module 4
+        "t969": 40.5,
+        "t970": 1.2,
+        "t812": 49,
+    }
+    result = translate_to_device_keys(decoded)
+    assert result == {
+        "battery1Mppt1InVol": 41.0,
+        "battery1Mppt1InCur": 1.5,
+        "battery1Mppt1InPower": 62,
+        "battery4Mppt1InVol": 40.5,
+        "battery4Mppt1InCur": 1.2,
+        "battery4Mppt1InPower": 49,
+    }
+
+
+def test_unmapped_registers_are_dropped():
+    """Local registers without a cloud equivalent are silently ignored."""
+    # t592 (head real SOC), t49 (daily generation), t586 (heater bitfield)
+    # all have no corresponding cloud entity key today.
+    result = translate_to_device_keys({"t592": 75, "t49": 1.234, "t586": 5})
+    assert result == {}
+
+
+def test_empty_input_returns_empty():
+    """A push with no data shouldn't synthesize keys."""
+    assert translate_to_device_keys({}) == {}


### PR DESCRIPTION
## Summary

Third slice of #179 — and the one that finally makes local mode user-visible.
The TCP foundation (#202) and the persisted host (#204) now feed real
entities: for any battery with local mode enabled and a host known from
zeroconf, the manager keeps a persistent TCP client connected and merges its
decoded pushes into the **same device coordinator** the cloud poll feeds.
Existing sensors just refresh faster; cloud stays as the floor.

## Design (recap)

- **Auto-gate, no new config.** The #160 local-mode switch *is* the on/off
  toggle: flip it on → manager starts the TCP client → entities update at
  push rate. Flip it off → manager tears down the client → entities go back
  to the 30 s cloud cadence.
- **Telemetry-first.** No new entity platforms. The local channel feeds the
  same `battery_level` / `batterySoc` / `batteryMpptN*` / `batteryNSoc` /
  `input_power_total` / `output_power_total` keys the cloud poll populates.
- **Cloud as the floor.** A dropped connection or a routine cloud poll both
  keep the integration alive; local pushes layer on top when connected.

## What changes

**`local/translate.py`** — pure mapping from decoded `tNNN` to existing cloud
keys. Covers system aggregates (`t211 -> battery_level + batterySoc`,
`t33/t34 -> input/output_power_total`), head MPPT 1 & 2 V/I/Power, modules
1..7 SOC + MPPT V/I/Power (including the `t1001`-`t1004` high-slot range).
Registers without a current cloud equivalent (`t592` head real SOC, `t49`
daily generation, `t586` heater bitfield) are dropped; they can be surfaced
as new local-only entities later.

**`local/manager.py`** — `LocalChannelManager` subscribes to each family's
device coordinator. On every update it reconciles per-battery: start a TCP
client when `support_local_mode && local_mode_enabled && host_known`, stop
it when any condition flips off. Telemetry callbacks translate and merge
into the coordinator via `async_set_updated_data`. Client factory is
injectable for tests.

**`__init__.py`** — builds the manager after coordinators have run their
first refresh; tears it down in `async_unload_entry`. Entries without a
batteries map (cloud-only setups, mDNS-blocked networks) get an empty map
and the manager simply never starts clients.

## Tests

- **7 translate tests**: system aggregates, module SOC slot coverage
  (including the high-slot range), head and module MPPTs, unmapped drops,
  empty input.
- **8 manager tests** with a fake coordinator + injectable client factory:
  start-on-enable, skip-on-missing-host, skip-on-flag-off,
  start-on-runtime-flip, stop-on-runtime-flip-off, telemetry merge,
  unknown-device push survival, full teardown.

```
.venv/bin/python -m pytest tests/ --asyncio-mode=auto
# 272 passed
```

## What's next

This makes #179's core opt-in path real. Possible later slices, not in scope
here:

- **Control entities** — `number` for SOC limits (`t362`/`t363`) and charge
  power (`t590`), `switch` for mode toggles (`t700`/`t701`/`t702`/`t728`),
  using `BK215LocalClient.set_register()` which already exists.
- **Local-only sensors** — surface `t592` head real SOC, `t49` daily
  generation, `t586` heater per-unit booleans, RSSI.
- **Derived-field freshness** — at the moment `stored_energy` is computed
  during cloud poll only, so it lags between polls even when local SOC is
  fresh. Cheap to recompute in the manager later.

Closes the part of #179 covered by tasks 1-3 (config flow + TCP client +
register decode + mapping). Tasks 4-5 (control entities, mock-server tests
for set) are deferred. Part of #163 epic.