### PR TITLE
docs(local): record verified protocol findings against live BK215

### DIFF
--- a/docs/local-protocol.md
+++ b/docs/local-protocol.md
@@ -1,9 +1,10 @@
 # BK215 local-mode (TCP) protocol
 
 Reverse-engineered reference for the **local** control/telemetry protocol exposed
-by the Sunlit / SunEnergyXT **BK215** battery when *local mode* is enabled. This
-is **not yet implemented** in this integration — it documents the protocol so a
-future opt-in local-polling channel can be built (see issue tracker).
+by the Sunlit / SunEnergyXT **BK215** battery when *local mode* is enabled. The
+opt-in local channel is implemented in `custom_components/sunlit/local/` (PRs
+#202, #204, #205). This file is the spec — annotated with what we've since
+verified against a live device (see the *Verification log* at the bottom).
 
 > Source: observed device behaviour plus the official, separate
 > `SunEnergyXT/SunEnergyXT-BK` Home Assistant plugin (`iot_class: local_polling`).
@@ -24,11 +25,16 @@ Local mode must be **on** for the device's TCP server to be reachable. The cloud
 stays authoritative for account/family aggregates, tariff, strategy and earnings
 (no local equivalent).
 
-**Open questions to verify before implementing:**
-- Does enabling local mode *divert* reporting away from the cloud (i.e. are the
-  two channels mutually exclusive for fresh data)?
-- Does the device accept only **one** TCP client at a time (app vs Home Assistant
-  contention)?
+**Status of the open questions:**
+
+- **Single-client lock:** ✅ confirmed against a live device. While one client
+  holds the TCP socket, the device both refuses new connections (port 8000
+  RSTs incoming SYNs) **and** stops advertising via mDNS. Closing the
+  occupying client restores both. So app vs HA cannot run concurrently —
+  whoever connects first owns the channel.
+- **Cloud-divert behaviour:** still unverified. We have not yet observed
+  whether enabling local mode freezes cloud freshness or whether the cloud
+  keeps polling normally.
 
 ## Discovery
 
@@ -42,6 +48,26 @@ mDNS / zeroconf — the same signal this integration already uses for onboarding
 - `port`, `serial_number`, `sw_version`, `hw_version`: from TXT properties
   (observed control port: **8000**)
 
+Observed real-world advertisement (firmware V1.5.8, ✅ verified 2026-05):
+
+```
+service:    _hp-bk215._http._tcp.local.
+host:       192.168.1.79         (from A-record)
+mDNS port:  8000                 (also 8000, not :80 — see note below)
+TXT:        id=DCBDCCBFFE3D      (MAC-style serial)
+            port=8000            (TCP control port; same as mDNS port here)
+            fw_ver=V1.5.8
+            model=20             (numeric model code, not "BK215")
+```
+
+Two things worth noting from this:
+
+- The **mDNS service port is also 8000**, not the HTTP-style 80 the name might
+  suggest. TXT `port` echoes it. Earlier wording implying mDNS advertised :80
+  was wrong — the TXT lookup remains the right source either way.
+- `model` is a **numeric code** (`'20'`), not the marketing name. Integrations
+  storing it as `hw_version` will see `"20"`, not `"BK215"`.
+
 ## Transport & framing
 
 - Plain **TCP** to `host:port`; persistent connection.
@@ -49,6 +75,24 @@ mDNS / zeroconf — the same signal this integration already uses for onboarding
 - Payload is **newline-delimited, compact JSON**, ASCII-encoded. Read in chunks
   and split on lines; ignore non-`{"code":...}` lines and keepalive bytes.
 - Heartbeat: if no data for ~60 s, drop and reconnect (poll connection ~every 5 s).
+
+**Observed cadence and content partitioning (verified 2026-05):**
+
+The three telemetry codes are not interchangeable snapshots — each one carries
+a different subset of registers and fires on a different schedule:
+
+| Code | Cadence | Carries |
+|---|---|---|
+| `0x6052` | every **~10 s** | total in/out power (`t33`,`t34`), MPPT V/I/Power (head + present modules), PV powers (`t50`,`t62`–`t65`,…), charging-box fields (`t711`,`t701_4`,`t702_4`,`t710`) |
+| `0x6060` | every **~60-90 s** | system SOC (`t211`), head & per-module real SOC (`t592`,`t593`,…), cell temps (`t220`,`t233`,…), heater bitfield (`t586`), RSSI (`t475`), daily energy (`t49`,`t66`) |
+| `0x6055` | **not observed** in 90 s | unknown — possibly event-driven or carries config-state registers (`t362/t363/t590`, mode switches) which never appeared in `0x6052`/`0x6060` |
+
+Because pushes are content-partitioned, a client building a "full snapshot"
+must **merge across pushes** — each push only overwrites the keys it carries.
+This is what `LocalChannelManager._push_telemetry` already does.
+
+The user-visible refresh-rate gain over the 30 s cloud poll is therefore
+"about 3×" for the values in `0x6052`, not "real-time."
 
 ```jsonc
 // telemetry push (device -> client)
@@ -94,10 +138,31 @@ stripped before sending. Then wait (~2 s) for a `0x6057` ack whose field value i
 | `−273` | `value - 273` (cell temperature, °C) |
 | `BITn` | bit *n* of the value (heater status, 0=main … 7=module 7) |
 
+### Unset sentinels
+
+- `0xFFFFFFFF` is the documented sentinel for "no value" — what an unset
+  register defaults to and what set-payloads strip before sending.
+- **`-1` is also used in the wild**, ✅ verified 2026-05. Observed on absent
+  modules (`t595=-1` when only 2 modules are present), no-charging-box fields
+  (`t711=-1`, `t701_4=-1`, `t702_4=-1`), and similar. Treat decoded `-1`
+  values the same as `0xFFFFFFFF` — i.e. drop them rather than scaling, since
+  otherwise you get nonsense like `t710 = -1 × 0.001 = -0.001 kWh` for a
+  battery that has no charging box at all.
+
 ## Register map
 
 The system has a **main** unit (BK215 head) plus up to **7** extension modules
 (B215). Registers below are grouped by access.
+
+> ⚠️ **None of the writable registers below appear in routine telemetry**
+> (verified 2026-05). Across 9 pushes / 90 s we observed `t362`, `t363`,
+> `t590`, `t700_1`, `t701_1`, `t702_1`, `t728` zero times — they're
+> configuration state, not real-time state. That means a "set + display
+> current value" entity has no read path from the local channel alone. They
+> may appear in `0x6055` pushes (which we also never observed), or only on
+> explicit query / change events. Until that's clarified, surface their
+> current values via the cloud strategy API (see issue #174) rather than
+> local-only `number`/`switch` entities.
 
 ### Writable — switches (booleans)
 
@@ -184,12 +249,43 @@ local registers onto the keys already used by the cloud coordinators, e.g.:
 
 | Local register(s) | Existing key |
 |---|---|
-| `t211` | `battery_level` |
-| `t592`–`t595`, `t1001`–`t1004` | `batteryNSoc` (per module) |
+| `t211` | `battery_level` (and `batterySoc`) |
+| `t593`–`t595`, `t1001`–`t1004` | `batteryNSoc` (modules 1–7) |
 | `t33` / `t34` | `input_power_total` / `output_power_total` |
 | `t536`/`t537` … | `batteryMppt1InVol`/`...InCur` (per MPPT) |
 | `t586` (bits) | `battery_heater_N` |
 | `t507`/`t508` | `hw_soc_min` / `hw_soc_max` |
 
-Writable registers (`t598`, `t362`, `t363`, `t590`, …) become `switch` / `number`
-control entities, complementing the cloud-side local-mode switch (#160).
+This is implemented in `local/translate.py`.
+
+**Local-only registers** (no cloud equivalent today; candidates for new
+diagnostic sensors): `t592` (head **real** SOC — meaningfully different from
+the system aggregate `t211`), `t49` (daily PV generation), `t66` (daily
+output energy), `t475` (RSSI, render as `-N dB`), `t586` (per-unit heater
+booleans split from the bitfield).
+
+**Writable registers** (`t598`, `t362`, `t363`, `t590`, mode toggles): kept
+deliberately out of scope for local control entities until the read-path
+question above is resolved. `t598` (local-mode enable) is already exposed
+via the cloud-side switch (#160), and SOC/strategy writing should route
+through the cloud strategy API (#174) where the value is observable.
+
+## Verification log
+
+Confirmations against a live BK215 on the user's LAN, **2026-05-28**:
+
+- Device: firmware `V1.5.8`, model code `'20'`.
+- Discovery: mDNS service `_hp-bk215._http._tcp.local.` at `192.168.1.79`,
+  TXT `port=8000` (matches mDNS service port).
+- Transport: TCP on 8000, persistent connection, newline-delimited JSON.
+- Cadence: `0x6052` every ~10 s, `0x6060` every ~60–90 s, `0x6055` not
+  observed in 90 s of listening.
+- Single-client lock: confirmed by experiment — phone app holds the socket,
+  HA gets `ConnectionRefused` and mDNS goes silent; closing the app restores
+  both.
+- `-1` sentinel observed in addition to documented `0xFFFFFFFF`.
+- Writable config registers (`t362/t363/t590`, mode toggles) never seen in
+  routine telemetry.
+
+Verified using `scripts/verify-local.py`. Cloud-divert behaviour and
+`0x6055` semantics remain to be tested.

--- a/scripts/verify-local.py
+++ b/scripts/verify-local.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Probe a live BK215 to verify the local-mode TCP protocol assumptions.
+
+Eats our own dogfood: imports the same ``custom_components.sunlit.local``
+modules the integration uses. If this script works against a real device,
+the integration code does too.
+
+By default the script is **read-only**: it discovers a BK215 via mDNS,
+opens a persistent TCP connection, prints decoded telemetry for 30 s,
+then quits. Pass ``--raw`` to see the unfiltered byte stream (e.g. to
+spot 0xAA keepalives the high-level client filters out). Pass
+``--write tNNN=value`` to test the set / 0x6057-ack path against one
+register; the flag is intentionally explicit so a write doesn't happen
+by accident.
+
+Usage::
+
+    .venv/bin/python scripts/verify-local.py
+    .venv/bin/python scripts/verify-local.py --listen 120
+    .venv/bin/python scripts/verify-local.py --host 192.168.1.50 --raw 15
+    .venv/bin/python scripts/verify-local.py --write t362=15  # CAREFUL
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from datetime import datetime
+from pathlib import Path
+import sys
+from typing import Any
+
+# Run-from-anywhere: make the repo importable without an install step.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from custom_components.sunlit.local.protocol import (  # noqa: E402
+    DEFAULT_PORT,
+    TELEMETRY_CODES,
+)
+from custom_components.sunlit.local.tcp_client import BK215LocalClient  # noqa: E402
+
+ZEROCONF_SERVICE_TYPE = "_http._tcp.local."
+ZEROCONF_NAME_FRAGMENT = "hp-bk215"
+
+
+def _now() -> str:
+    """Compact ISO timestamp with milliseconds for diagnostic output."""
+    return datetime.now().strftime("%H:%M:%S.%f")[:-3]
+
+
+async def discover_bk215(timeout: float = 5.0) -> dict[str, Any] | None:
+    """Browse mDNS for ``hp-bk215*`` and return its (host, port, props).
+
+    Returns ``None`` if nothing is found within ``timeout`` seconds. The
+    returned dict carries the parsed first IP address, the TXT ``port``
+    value (the TCP control port, not the mDNS service port), and the full
+    TXT properties so a caller can spot-check our assumptions.
+    """
+    from zeroconf import ServiceStateChange
+    from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
+
+    found: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+
+    resolve_tasks: list[asyncio.Task] = []
+
+    def _handler(*, zeroconf, service_type, name, state_change):
+        if state_change != ServiceStateChange.Added:
+            return
+        if ZEROCONF_NAME_FRAGMENT not in name.lower():
+            return
+        resolve_tasks.append(
+            asyncio.create_task(_resolve(zeroconf, service_type, name))
+        )
+
+    async def _resolve(zc, service_type, name):
+        info = AsyncServiceInfo(service_type, name)
+        if not await info.async_request(zc, 3000):
+            return
+        addresses = info.parsed_addresses()
+        if not addresses:
+            return
+        properties = {
+            (k.decode() if isinstance(k, bytes) else k): (
+                v.decode() if isinstance(v, bytes) else v
+            )
+            for k, v in (info.properties or {}).items()
+        }
+        host = addresses[0]
+        # TXT carries the control port; the mDNS service port is the _http
+        # port and not what the local channel uses.
+        port_raw = properties.get("port")
+        try:
+            port = int(port_raw) if port_raw is not None else DEFAULT_PORT
+        except (TypeError, ValueError):
+            port = DEFAULT_PORT
+        if not found.done():
+            found.set_result(
+                {
+                    "service_name": name,
+                    "host": host,
+                    "addresses": addresses,
+                    "service_port": info.port,
+                    "tcp_port": port,
+                    "properties": properties,
+                }
+            )
+
+    azc = AsyncZeroconf()
+    browser = AsyncServiceBrowser(
+        azc.zeroconf, [ZEROCONF_SERVICE_TYPE], handlers=[_handler]
+    )
+    try:
+        return await asyncio.wait_for(found, timeout=timeout)
+    except TimeoutError:
+        return None
+    finally:
+        await browser.async_cancel()
+        await azc.async_close()
+
+
+def _format_discovery(info: dict[str, Any]) -> str:
+    lines = [
+        f"  service:    {info['service_name']}",
+        f"  host:       {info['host']}  (all: {info['addresses']})",
+        f"  mDNS port:  {info['service_port']}  (the _http port; not used)",
+        f"  TCP port:   {info['tcp_port']}  (from TXT 'port'; used by local channel)",
+        "  TXT properties:",
+    ]
+    for key, value in sorted(info["properties"].items()):
+        lines.append(f"    {key}: {value!r}")
+    return "\n".join(lines)
+
+
+async def listen_decoded(host: str, port: int, seconds: float) -> None:
+    """Listen for ``seconds`` and print every decoded telemetry push.
+
+    Also tracks the per-code message counts so we can confirm the protocol
+    doc's claim about three telemetry kinds (0x6052/0x6055/0x6060).
+    """
+    push_count = 0
+    code_counts: dict[int, int] = dict.fromkeys(TELEMETRY_CODES, 0)
+    field_counts: dict[str, int] = {}
+    state_history: list[tuple[str, bool]] = []
+
+    def _on_telemetry(decoded: dict[str, Any]) -> None:
+        nonlocal push_count
+        push_count += 1
+        for field in decoded:
+            field_counts[field] = field_counts.get(field, 0) + 1
+        compact = ", ".join(f"{k}={v}" for k, v in sorted(decoded.items()))
+        print(f"[{_now()}]  #{push_count:>3}  {compact}")
+
+    def _on_state(connected: bool) -> None:
+        state_history.append((_now(), connected))
+        marker = "connected" if connected else "disconnected"
+        print(f"[{_now()}]  -- {marker} --")
+
+    client = BK215LocalClient(
+        host=host,
+        port=port,
+        on_telemetry=_on_telemetry,
+        on_state_change=_on_state,
+        name=f"{host}:{port}",
+    )
+
+    # We can't intercept code counts via the high-level client, so we also
+    # tap the raw line stream by patching _handle_message. Cheaper than
+    # reimplementing the connection.
+    original_handle = client._handle_message
+
+    def _counting_handle(code: int, data: dict[str, int]) -> None:
+        if code in code_counts:
+            code_counts[code] += 1
+        original_handle(code, data)
+
+    client._handle_message = _counting_handle  # type: ignore[assignment]
+
+    client.start()
+    try:
+        await asyncio.sleep(seconds)
+    finally:
+        await client.async_stop()
+
+    print()
+    print(f"Listened for {seconds:.1f}s; received {push_count} telemetry pushes.")
+    if push_count:
+        rate = push_count / seconds
+        print(f"  Push rate:  {rate:.2f}/s  ({1 / rate:.2f}s between pushes)")
+    print("  Per-code counts:")
+    for code, count in sorted(code_counts.items()):
+        print(f"    0x{code:04X} ({code}): {count}")
+    print(f"  Distinct fields seen: {len(field_counts)}")
+    top_fields = sorted(field_counts.items(), key=lambda kv: -kv[1])[:15]
+    for field, count in top_fields:
+        print(f"    {field}: {count}")
+    if state_history:
+        print(f"  State transitions: {len(state_history)}")
+
+
+async def listen_raw(host: str, port: int, seconds: float) -> None:
+    """Dump raw bytes from the socket, both hex and ASCII, for ``seconds``.
+
+    This bypasses the protocol layer entirely so we can observe the 0xAA
+    keepalive bytes the doc mentions but the high-level client filters
+    out, plus any framing oddities (concatenated objects, etc.).
+    """
+    print(f"[{_now()}]  opening raw TCP {host}:{port}")
+    reader, writer = await asyncio.wait_for(
+        asyncio.open_connection(host, port), timeout=5.0
+    )
+    print(f"[{_now()}]  connected; reading for {seconds:.1f}s")
+
+    total = 0
+    keepalive_count = 0
+    try:
+        end_at = asyncio.get_running_loop().time() + seconds
+        while True:
+            remaining = end_at - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                break
+            try:
+                chunk = await asyncio.wait_for(reader.read(4096), timeout=remaining)
+            except TimeoutError:
+                break
+            if not chunk:
+                print(f"[{_now()}]  peer closed connection")
+                break
+            total += len(chunk)
+            keepalive_count += chunk.count(b"\xaa")
+            preview = chunk[:96]
+            hex_preview = preview.hex(" ")
+            ascii_preview = "".join(
+                c if 32 <= ord(c) < 127 else "." for c in preview.decode("latin-1")
+            )
+            print(
+                f"[{_now()}]  +{len(chunk):>4}B  "
+                f"hex={hex_preview}{'...' if len(chunk) > 96 else ''}"
+            )
+            print(f"             ascii={ascii_preview!r}")
+    finally:
+        writer.close()
+        try:
+            await asyncio.wait_for(writer.wait_closed(), timeout=2.0)
+        except (TimeoutError, OSError):
+            pass
+
+    print()
+    print(f"Raw bytes received: {total}")
+    print(f"  0xAA bytes (keepalives): {keepalive_count}")
+
+
+def _parse_write(spec: str) -> tuple[str, int]:
+    """Parse ``--write tNNN=value`` into (field, int_value)."""
+    if "=" not in spec:
+        raise argparse.ArgumentTypeError(f"--write must be FIELD=VALUE, got {spec!r}")
+    field, value_str = spec.split("=", 1)
+    field = field.strip()
+    try:
+        value = int(value_str.strip())
+    except ValueError as err:
+        raise argparse.ArgumentTypeError(
+            f"--write value must be an int, got {value_str!r}"
+        ) from err
+    if not field.startswith("t"):
+        raise argparse.ArgumentTypeError(
+            f"--write field must look like 'tNNN', got {field!r}"
+        )
+    return field, value
+
+
+async def perform_write(host: str, port: int, field: str, value: int) -> None:
+    """Send one set request, await its ack, and watch the value stick."""
+    pre_values: list[int] = []
+    post_values: list[int] = []
+    phase = {"name": "pre"}
+
+    def _capture(decoded: dict[str, Any]) -> None:
+        if field not in decoded:
+            return
+        target = pre_values if phase["name"] == "pre" else post_values
+        target.append(decoded[field])
+        print(f"[{_now()}]  observed {field}={decoded[field]} ({phase['name']})")
+
+    client = BK215LocalClient(
+        host=host, port=port, on_telemetry=_capture, name=f"{host}:{port}"
+    )
+    client.start()
+
+    try:
+        # Watch for ~5 s so we capture the current value before mutating.
+        print(f"[{_now()}]  pre-write listen for 5s to capture {field} baseline")
+        await asyncio.sleep(5.0)
+        baseline = pre_values[-1] if pre_values else None
+        print(f"[{_now()}]  baseline {field}={baseline!r}  ->  writing {value}")
+
+        phase["name"] = "post"
+        ok = await client.set_register(field, value)
+        print(f"[{_now()}]  set-ack success={ok}")
+
+        # Listen for ~15 s to confirm the change persists in subsequent
+        # telemetry pushes.
+        print(f"[{_now()}]  post-write listen for 15s to confirm {field}")
+        await asyncio.sleep(15.0)
+
+        if post_values:
+            print(f"[{_now()}]  post-write {field} values seen: {post_values}")
+            if all(v == value for v in post_values):
+                print(f"[{_now()}]  ✓ device telemetry now reports {field}={value}")
+            else:
+                print(f"[{_now()}]  ✗ telemetry did NOT settle on {value}")
+        else:
+            print(f"[{_now()}]  (no post-write {field} pushes observed; can't confirm)")
+
+        if baseline is not None and baseline != value:
+            print(
+                f"[{_now()}]  REMINDER: original value was {baseline}; "
+                f"re-run with --write {field}={baseline} to restore."
+            )
+    finally:
+        await client.async_stop()
+
+
+async def _amain(args: argparse.Namespace) -> int:
+    if args.host is None:
+        print(f"[{_now()}]  discovering hp-bk215* via mDNS...")
+        discovery = await discover_bk215(timeout=args.discovery_timeout)
+        if discovery is None:
+            print("No BK215 found on the local network.")
+            print("Pass --host HOST [--port PORT] to skip discovery.")
+            return 2
+        print(_format_discovery(discovery))
+        host = discovery["host"]
+        port = args.port if args.port is not None else discovery["tcp_port"]
+    else:
+        host = args.host
+        port = args.port if args.port is not None else DEFAULT_PORT
+
+    print()
+    print(f"[{_now()}]  target = {host}:{port}")
+    print()
+
+    if args.write is not None:
+        if args.raw:
+            print("--write and --raw are mutually exclusive.")
+            return 2
+        field, value = args.write
+        await perform_write(host, port, field, value)
+    elif args.raw:
+        await listen_raw(host, port, args.raw)
+    else:
+        await listen_decoded(host, port, args.listen)
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--host",
+        help="LAN address of the BK215 (skip mDNS discovery).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        help=f"TCP control port (default: TXT 'port' or {DEFAULT_PORT}).",
+    )
+    parser.add_argument(
+        "--listen",
+        type=float,
+        default=30.0,
+        help="Seconds to listen for decoded telemetry (default: 30).",
+    )
+    parser.add_argument(
+        "--raw",
+        nargs="?",
+        type=float,
+        const=15.0,
+        default=None,
+        metavar="SECS",
+        help="Print raw socket bytes (no protocol parsing) for N seconds (default 15).",
+    )
+    parser.add_argument(
+        "--write",
+        type=_parse_write,
+        metavar="FIELD=VALUE",
+        help="(MUTATING) Write one register and confirm via ack + telemetry.",
+    )
+    parser.add_argument(
+        "--discovery-timeout",
+        type=float,
+        default=5.0,
+        help="Seconds to wait for mDNS discovery (default: 5).",
+    )
+    args = parser.parse_args()
+    return asyncio.run(_amain(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two related commits:

1. **`scripts/verify-local.py`** — a standalone Python tool that imports the
   same `custom_components.sunlit.local` modules the integration uses, so a
   successful run against a real device verifies the production code path
   too. Read-only by default; `--write FIELD=VALUE` and `--raw` are
   explicit opt-ins.

2. **`docs/local-protocol.md`** — amended in place with what we've now
   confirmed against a real BK215 (firmware V1.5.8) using that script.

Branch is `chore:` + `docs:` only, so release-please won't cut a version.

## What was verified

| Open question | Status |
|---|---|
| Single-client lock | ✅ Confirmed — while one client owns port 8000, the device RSTs new SYNs *and* stops advertising mDNS. App vs HA cannot run concurrently. |
| TXT `port` value | ✅ `8000` (matches mDNS service port — there is no `:80`) |
| `model` TXT field | Numeric code `'20'`, not `'BK215'` |
| Push cadence | `0x6052` every ~10 s, `0x6060` every ~60-90 s, `0x6055` not observed in 90 s |
| Content partitioning | Each code carries a disjoint key subset — clients must merge across pushes |
| `-1` is also a sentinel | Yes, observed on absent modules and no-charging-box fields. Causes nonsense like `t710 = -0.001 kWh` if not filtered. |
| Writable config in telemetry | ⚠️ **None of `t362/t363/t590` or the mode-toggle switches appear in routine telemetry.** Kills the "set + display current value" design for local control entities — cloud strategy API (#174) is the right home for that. |
| Cloud-divert behaviour | Still unverified, marked as such |

## Doc changes

Inline updates to: lead paragraph (reflects shipped state), the open-questions
section, Discovery (real TXT example), Transport & framing (cadence table),
Value scaling (new "Unset sentinels" subsection), Register map (warning above
the writable subsections), Mapping (fixes `t592` placement, lists local-only
sensor candidates, removes "writable registers become switch/number" claim).

New "Verification log" footer summarising what was tested, on what date,
against what firmware.

## What's deliberately left alone

- The `-1` sentinel filtering in `decode_telemetry` is **documented but not
  yet patched in code** — separate small PR.
- The local-only sensors design (`t592`, `t49`, `t66`, `t475`, `t586` bits)
  is now documented as the natural next slice but not built here.
- The cloud-divert question and `0x6055` semantics are noted as still-open
  in the doc; would need more probing on the live device.

## Test plan

Script verified end-to-end on a live device in this session (mDNS discovery,
20s and 90s decoded listens, raw probe, ConnectionRefused observation when
the app held the socket, recovery on app close).

No HA test changes; this is docs + tooling only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced local protocol specification with device-verified observations, including discovery behavior, socket management, telemetry delivery requirements, protocol sentinel handling, and register-to-entity mappings.

* **New Features**
  * Added verification utility script to validate local protocol implementation against live devices and test connectivity, discovery, and telemetry behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/ha-sunlit/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->