### PR TITLE
feat(local): expose head SOC, daily energy and RSSI as local-only sensors

### DIFF
--- a/custom_components/sunlit/const.py
+++ b/custom_components/sunlit/const.py
@@ -132,6 +132,12 @@ BATTERY_SENSORS = {
     # Diagnostics from device details (#159)
     "wifi_ssid": "WiFi SSID",
     "system_status": "System Status",
+    # Local-only sensors (populated by the local-mode TCP channel; stay
+    # unavailable while the channel is disconnected or local mode is off)
+    "head_battery_soc": "Head Unit Battery SOC",
+    "daily_pv_energy": "Daily PV Energy",
+    "daily_output_energy": "Daily Output Energy",
+    "wifi_rssi": "WiFi Signal Strength",
 }
 
 # Battery module specific sensors (will be created for each module 1, 2, 3)

--- a/custom_components/sunlit/entities/helpers.py
+++ b/custom_components/sunlit/entities/helpers.py
@@ -9,6 +9,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS,
     EntityCategory,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
@@ -37,7 +38,14 @@ ENUM_SENSOR_OPTIONS: dict[str, list[str]] = {
 # Battery SOC that is actually metered and fluctuates -> SensorDeviceClass.BATTERY.
 # SOC *limits* (hw/bms/strategy/current min/max) are configuration thresholds,
 # not metered battery levels, so they are deliberately excluded.
-_METERED_SOC_KEYS = {"battery_level", "batterySoc", "average_battery_level"}
+_METERED_SOC_KEYS = {
+    "battery_level",
+    "batterySoc",
+    "average_battery_level",
+    # Head unit SOC from the local channel (t592) is metered just like the
+    # per-module battery1Soc..battery7Soc readings.
+    "head_battery_soc",
+}
 _MODULE_SOC_RE = re.compile(r"^battery\d+Soc$")
 
 
@@ -81,6 +89,9 @@ def get_device_class_for_sensor(key: str) -> SensorDeviceClass | None:
     # Home power
     elif key == "home_power":
         return SensorDeviceClass.POWER
+    # WiFi RSSI from the local channel (t475 -> negative dB).
+    elif key == "wifi_rssi":
+        return SensorDeviceClass.SIGNAL_STRENGTH
     # Time remaining sensors
     elif "remaining" in key.lower():
         return SensorDeviceClass.DURATION
@@ -139,6 +150,7 @@ def get_state_class_for_sensor(key: str) -> SensorStateClass | None:
         SensorDeviceClass.BATTERY,
         SensorDeviceClass.DURATION,
         SensorDeviceClass.ENERGY_STORAGE,
+        SensorDeviceClass.SIGNAL_STRENGTH,
     ):
         return SensorStateClass.MEASUREMENT
     # Numeric measurements that carry no device class (counts, prices, rates).
@@ -173,6 +185,9 @@ def get_unit_for_sensor(key: str) -> str | None:
         or key in ["total_power_generation", "total_yield"]
     ):
         return UnitOfEnergy.KILO_WATT_HOUR
+    # WiFi RSSI (t475 -> negative dB)
+    elif key == "wifi_rssi":
+        return SIGNAL_STRENGTH_DECIBELS
     # Time remaining sensors
     elif "remaining" in key.lower():
         return UnitOfTime.MINUTES
@@ -373,6 +388,9 @@ def get_entity_category(key: str) -> EntityCategory | None:
     Nominal capacity is a static hardware spec, not live telemetry -> diagnostic.
     """
     if key == "battery_capacity" or key.endswith("capacity"):
+        return EntityCategory.DIAGNOSTIC
+    # WiFi RSSI is a connection-health signal, not primary telemetry.
+    if key == "wifi_rssi":
         return EntityCategory.DIAGNOSTIC
     return None
 

--- a/custom_components/sunlit/local/protocol.py
+++ b/custom_components/sunlit/local/protocol.py
@@ -26,8 +26,14 @@ from typing import Any
 # port is advertised in the TXT ``port`` property (not the _http service port).
 DEFAULT_PORT = 8000
 
-# A register carrying this value is unset and should be treated as "no data".
+# Values that mean "no data" and must not be scaled. The unsigned-max value
+# is the documented sentinel; ``-1`` shows up in the wild on absent modules
+# (e.g. ``t595=-1`` when only modules 1 and 2 are populated) and on
+# no-charging-box fields (``t710``, ``t711``, ``t701_4``, ``t702_4``).
+# Without filtering both, scaled-by-0.001 fields turn into nonsense like
+# ``t710 = -0.001 kWh``. Verified against firmware V1.5.8 (2026-05).
 UNSET = 0xFFFFFFFF
+UNSET_VALUES: frozenset[int] = frozenset({UNSET, -1})
 
 # --- Message codes ---------------------------------------------------------
 
@@ -58,12 +64,22 @@ def _offset(offset: int) -> Decoder:
     return lambda raw: raw - offset
 
 
+def _rssi(raw: int) -> int:
+    """Decode ``t475`` RSSI: the magnitude is reported positive; dB is negative.
+
+    The device sends e.g. ``80`` for a real-world signal strength of ``-80 dB``.
+    Storing the negated value lets sensors render as plain ``dB`` without any
+    custom display logic.
+    """
+    return -raw
+
+
 def heater_bits(raw: int) -> list[bool]:
     """Split the ``t586`` heater bitfield into per-unit booleans.
 
     Bit 0 is the main unit, bits 1..7 are extension modules 1..7.
     """
-    if raw == UNSET:
+    if raw in UNSET_VALUES:
         return []
     return [bool((raw >> bit) & 1) for bit in range(8)]
 
@@ -143,7 +159,7 @@ def _build_registers() -> dict[str, Register]:
         "t544": _voltage(),
         "t545": _current(),
         "t586": Register(int, None, None),  # heater bitfield (use heater_bits)
-        "t475": Register(int, "dB", "signal_strength"),  # RSSI (see decode note)
+        "t475": Register(_rssi, "dB", "signal_strength"),  # RSSI -> negative dB
     }
     # SOC per unit
     for reg in _MODULE_SOC:
@@ -167,12 +183,13 @@ REGISTERS: dict[str, Register] = _build_registers()
 def decode_telemetry(data: dict[str, int]) -> dict[str, Any]:
     """Decode a raw telemetry ``data`` map into scaled values.
 
-    Unset registers (``0xFFFFFFFF``) and unknown register names are dropped.
-    Known registers are scaled per their :class:`Register` definition.
+    Registers carrying an "unset" sentinel (see :data:`UNSET_VALUES`) and
+    registers without a known scaling definition are both dropped. Known
+    registers are scaled per their :class:`Register` definition.
     """
     decoded: dict[str, Any] = {}
     for name, raw in data.items():
-        if raw == UNSET:
+        if raw in UNSET_VALUES:
             continue
         register = REGISTERS.get(name)
         if register is None:

--- a/custom_components/sunlit/local/translate.py
+++ b/custom_components/sunlit/local/translate.py
@@ -18,11 +18,22 @@ from typing import Any
 # tNNN -> tuple of cloud entity keys it should populate. A few local
 # registers map to multiple cloud keys because the cloud surfaces the
 # same value under more than one name (e.g. system SOC).
+#
+# Some registers map to **local-only** keys that the cloud never populates;
+# their entities stay unavailable until the local channel is active. They
+# expose information the cloud doesn't (head unit SOC distinct from the
+# system aggregate, RSSI for connection health, per-battery daily energy
+# counters).
 _REGISTER_TO_CLOUD_KEYS: dict[str, tuple[str, ...]] = {
     # System aggregates (head + all modules)
     "t211": ("battery_level", "batterySoc"),
     "t33": ("input_power_total",),
     "t34": ("output_power_total",),
+    # Local-only (no cloud equivalent)
+    "t592": ("head_battery_soc",),  # head unit real SOC vs system t211 average
+    "t49": ("daily_pv_energy",),  # daily PV generation as the battery sees it
+    "t66": ("daily_output_energy",),  # daily energy out of the battery
+    "t475": ("wifi_rssi",),  # already negated by decode -> negative dB
     # Head unit MPPTs (1 and 2)
     "t536": ("batteryMppt1InVol",),
     "t537": ("batteryMppt1InCur",),
@@ -76,11 +87,11 @@ def translate_to_device_keys(decoded: dict[str, Any]) -> dict[str, Any]:
     is a partial cloud-key map to merge into one battery device's slot in
     ``device_coordinator.data["devices"][device_id]``.
 
-    Registers without a known cloud mapping (e.g. ``t592`` head real SOC,
-    ``t49`` daily generation, ``t586`` heater bitfield) are dropped. They
-    can be surfaced later as new local-only entities; until then the cloud
-    poll continues to be the source of truth for derived fields like
-    ``stored_energy``, which won't refresh from local pushes alone.
+    Registers without a known cloud or local-only mapping (e.g. ``t586``
+    heater bitfield, BMS hardware SOC limits) are dropped. They can be
+    surfaced later as new entities; until then the cloud poll continues to
+    be the source of truth for derived fields like ``stored_energy``,
+    which won't refresh from local pushes alone.
     """
     result: dict[str, Any] = {}
     for register, value in decoded.items():

--- a/tests/test_local_protocol.py
+++ b/tests/test_local_protocol.py
@@ -36,6 +36,20 @@ def test_decode_drops_unset_sentinel():
     assert decoded["t33"] == 100
 
 
+def test_decode_drops_negative_one_sentinel():
+    """-1 is used as 'no value' on absent modules and missing charging-box.
+
+    Without filtering, x0.001 fields turn into -0.001 kWh nonsense. Verified
+    against firmware V1.5.8 (2026-05): t595=-1 for absent module 3, t710=-1
+    when no charging box is attached.
+    """
+    decoded = protocol.decode_telemetry(
+        {"t595": -1, "t710": -1, "t711": -1, "t701_4": -1, "t211": 73}
+    )
+    # All -1 readings are dropped, but the real value survives.
+    assert decoded == {"t211": 73}
+
+
 def test_decode_drops_unknown_registers():
     """Registers not in the map are ignored rather than passed through raw."""
     decoded = protocol.decode_telemetry({"t999": 5, "t211": 42})
@@ -49,6 +63,12 @@ def test_module_soc_registers_present():
     assert all(decoded[reg] == 80 for reg in raw)
 
 
+def test_rssi_decodes_to_negative_db():
+    """t475 carries the magnitude; the dB value (and HA sensor) is negative."""
+    decoded = protocol.decode_telemetry({"t475": 80})
+    assert decoded == {"t475": -80}
+
+
 def test_heater_bits():
     """The t586 bitfield splits into head + module booleans."""
     # bits 0 (main) and 2 (module 2) set => 0b101 = 5
@@ -57,6 +77,10 @@ def test_heater_bits():
     assert bits[1] is False
     assert bits[2] is True
     assert protocol.heater_bits(protocol.UNSET) == []
+    # -1 is also a sentinel (verified against live device)
+    assert protocol.heater_bits(-1) == []
+    # Live-observed common case: no heaters working
+    assert protocol.heater_bits(0) == [False] * 8
 
 
 def test_is_protocol_line_filters():

--- a/tests/test_local_translate.py
+++ b/tests/test_local_translate.py
@@ -84,11 +84,27 @@ def test_module_mppt_voltage_current_power():
     }
 
 
+def test_local_only_registers_populate_dedicated_keys():
+    """Registers without a cloud equivalent map to local-only entity keys."""
+    # t592 = head unit real SOC (distinct from system aggregate t211)
+    # t49  = daily PV generation (cloud doesn't track this per battery)
+    # t66  = daily output energy (cloud doesn't track this per battery)
+    # t475 = WiFi RSSI in dB (already negated by decode)
+    result = translate_to_device_keys(
+        {"t592": 78, "t49": 1.234, "t66": 0.42, "t475": -80}
+    )
+    assert result == {
+        "head_battery_soc": 78,
+        "daily_pv_energy": 1.234,
+        "daily_output_energy": 0.42,
+        "wifi_rssi": -80,
+    }
+
+
 def test_unmapped_registers_are_dropped():
-    """Local registers without a cloud equivalent are silently ignored."""
-    # t592 (head real SOC), t49 (daily generation), t586 (heater bitfield)
-    # all have no corresponding cloud entity key today.
-    result = translate_to_device_keys({"t592": 75, "t49": 1.234, "t586": 5})
+    """Local registers we have no entity for are silently ignored."""
+    # t586 (heater bitfield) and BMS hardware SOC limits have no entity yet.
+    result = translate_to_device_keys({"t586": 5, "t507": 5, "t508": 95})
     assert result == {}
 
 

--- a/tests/test_sensor_helpers.py
+++ b/tests/test_sensor_helpers.py
@@ -3,6 +3,7 @@
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
     PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS,
     EntityCategory,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
@@ -48,9 +49,9 @@ class TestDeviceClassForSensor:
             "batteryMppt1Energy",
         ]
         for sensor in energy_sensors:
-            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.ENERGY, (
-                f"Failed for {sensor}"
-            )
+            assert (
+                get_device_class_for_sensor(sensor) == SensorDeviceClass.ENERGY
+            ), f"Failed for {sensor}"
 
     def test_capacity_is_not_energy(self):
         """Nominal capacity is a static spec, not metered energy (no device class)."""
@@ -72,9 +73,9 @@ class TestDeviceClassForSensor:
             "batteryMppt1InPower",
         ]
         for sensor in power_sensors:
-            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.POWER, (
-                f"Failed for {sensor}"
-            )
+            assert (
+                get_device_class_for_sensor(sensor) == SensorDeviceClass.POWER
+            ), f"Failed for {sensor}"
 
     def test_battery_sensors(self):
         """Only metered, fluctuating SOC is BATTERY (issue: validate sensors)."""
@@ -84,11 +85,13 @@ class TestDeviceClassForSensor:
             "batterySoc",
             "battery1Soc",
             "battery2Soc",
+            # Head unit real SOC from the local channel (t592)
+            "head_battery_soc",
         ]
         for sensor in battery_sensors:
-            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.BATTERY, (
-                f"Failed for {sensor}"
-            )
+            assert (
+                get_device_class_for_sensor(sensor) == SensorDeviceClass.BATTERY
+            ), f"Failed for {sensor}"
 
     def test_soc_limits_are_not_battery(self):
         """SOC limit thresholds are config values, not metered battery levels."""
@@ -114,9 +117,9 @@ class TestDeviceClassForSensor:
             "battery_discharging_remaining",
         ]
         for sensor in duration_sensors:
-            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.DURATION, (
-                f"Failed for {sensor}"
-            )
+            assert (
+                get_device_class_for_sensor(sensor) == SensorDeviceClass.DURATION
+            ), f"Failed for {sensor}"
 
     def test_voltage_sensors(self):
         """Test voltage sensor classification."""
@@ -126,9 +129,9 @@ class TestDeviceClassForSensor:
             "battery1Mppt1InVol",
         ]
         for sensor in voltage_sensors:
-            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.VOLTAGE, (
-                f"Failed for {sensor}"
-            )
+            assert (
+                get_device_class_for_sensor(sensor) == SensorDeviceClass.VOLTAGE
+            ), f"Failed for {sensor}"
 
     def test_current_sensors(self):
         """Test current sensor classification."""
@@ -138,9 +141,9 @@ class TestDeviceClassForSensor:
             "battery1Mppt1InCur",
         ]
         for sensor in current_sensors:
-            assert get_device_class_for_sensor(sensor) == SensorDeviceClass.CURRENT, (
-                f"Failed for {sensor}"
-            )
+            assert (
+                get_device_class_for_sensor(sensor) == SensorDeviceClass.CURRENT
+            ), f"Failed for {sensor}"
 
     def test_monetary_sensor(self):
         """Test monetary sensor classification."""
@@ -216,9 +219,9 @@ class TestStateClassForSensor:
             "lifetime_earnings",
         ]
         for sensor in total_sensors:
-            assert get_state_class_for_sensor(sensor) == SensorStateClass.TOTAL, (
-                f"Failed for {sensor}"
-            )
+            assert (
+                get_state_class_for_sensor(sensor) == SensorStateClass.TOTAL
+            ), f"Failed for {sensor}"
 
     def test_measurement_sensors(self):
         """Test sensors with measurement state class."""
@@ -238,9 +241,9 @@ class TestStateClassForSensor:
             "total_solar_power",
         ]
         for sensor in measurement_sensors:
-            assert get_state_class_for_sensor(sensor) == SensorStateClass.MEASUREMENT, (
-                f"Failed for {sensor}"
-            )
+            assert (
+                get_state_class_for_sensor(sensor) == SensorStateClass.MEASUREMENT
+            ), f"Failed for {sensor}"
 
     def test_no_state_class_sensors(self):
         """Test sensors that should have no state class."""
@@ -278,9 +281,9 @@ class TestUnitForSensor:
             "battery_capacity",
         ]
         for sensor in energy_sensors:
-            assert get_unit_for_sensor(sensor) == UnitOfEnergy.KILO_WATT_HOUR, (
-                f"Failed for {sensor}"
-            )
+            assert (
+                get_unit_for_sensor(sensor) == UnitOfEnergy.KILO_WATT_HOUR
+            ), f"Failed for {sensor}"
 
     def test_power_units(self):
         """Test power sensors return W."""
@@ -292,9 +295,9 @@ class TestUnitForSensor:
             "home_power",
         ]
         for sensor in power_sensors:
-            assert get_unit_for_sensor(sensor) == UnitOfPower.WATT, (
-                f"Failed for {sensor}"
-            )
+            assert (
+                get_unit_for_sensor(sensor) == UnitOfPower.WATT
+            ), f"Failed for {sensor}"
 
     def test_percentage_units(self):
         """Test battery/SOC sensors return %."""
@@ -316,9 +319,9 @@ class TestUnitForSensor:
             "battery_charging_remaining",
         ]
         for sensor in time_sensors:
-            assert get_unit_for_sensor(sensor) == UnitOfTime.MINUTES, (
-                f"Failed for {sensor}"
-            )
+            assert (
+                get_unit_for_sensor(sensor) == UnitOfTime.MINUTES
+            ), f"Failed for {sensor}"
 
     def test_voltage_units(self):
         """Test voltage sensors return V."""
@@ -327,9 +330,9 @@ class TestUnitForSensor:
             "batteryMppt2InVol",
         ]
         for sensor in voltage_sensors:
-            assert get_unit_for_sensor(sensor) == UnitOfElectricPotential.VOLT, (
-                f"Failed for {sensor}"
-            )
+            assert (
+                get_unit_for_sensor(sensor) == UnitOfElectricPotential.VOLT
+            ), f"Failed for {sensor}"
 
     def test_current_units(self):
         """Test current sensors return A."""
@@ -338,9 +341,9 @@ class TestUnitForSensor:
             "batteryMppt2InCur",
         ]
         for sensor in current_sensors:
-            assert get_unit_for_sensor(sensor) == UnitOfElectricCurrent.AMPERE, (
-                f"Failed for {sensor}"
-            )
+            assert (
+                get_unit_for_sensor(sensor) == UnitOfElectricCurrent.AMPERE
+            ), f"Failed for {sensor}"
 
     def test_monetary_units(self):
         """Test monetary sensor returns EUR."""
@@ -491,6 +494,42 @@ class TestSensorMetadataExtras:
         assert get_suggested_display_precision(key) == precision
 
 
+class TestLocalOnlySensors:
+    """Validate metadata for the local-channel-only battery sensors."""
+
+    def test_head_battery_soc_is_metered_battery(self):
+        """t592 -> head_battery_soc behaves like the per-module SOC keys."""
+        assert (
+            get_device_class_for_sensor("head_battery_soc") == SensorDeviceClass.BATTERY
+        )
+        assert (
+            get_state_class_for_sensor("head_battery_soc")
+            == SensorStateClass.MEASUREMENT
+        )
+        assert get_unit_for_sensor("head_battery_soc") == PERCENTAGE
+        # Primary telemetry, not diagnostic.
+        assert get_entity_category("head_battery_soc") is None
+
+    def test_daily_energy_keys_are_total_increasing(self):
+        """Local daily energy counters behave like the cloud daily_yield."""
+        for key in ("daily_pv_energy", "daily_output_energy"):
+            assert get_device_class_for_sensor(key) == SensorDeviceClass.ENERGY, key
+            assert (
+                get_state_class_for_sensor(key) == SensorStateClass.TOTAL_INCREASING
+            ), key
+            assert get_unit_for_sensor(key) == UnitOfEnergy.KILO_WATT_HOUR, key
+
+    def test_wifi_rssi_is_diagnostic_signal_strength(self):
+        """t475 -> wifi_rssi: SIGNAL_STRENGTH device class, dB unit, diagnostic."""
+        assert (
+            get_device_class_for_sensor("wifi_rssi")
+            == SensorDeviceClass.SIGNAL_STRENGTH
+        )
+        assert get_state_class_for_sensor("wifi_rssi") == SensorStateClass.MEASUREMENT
+        assert get_unit_for_sensor("wifi_rssi") == SIGNAL_STRENGTH_DECIBELS
+        assert get_entity_category("wifi_rssi") == EntityCategory.DIAGNOSTIC
+
+
 class TestStoredEnergySensors:
     """Test classification of battery stored-energy sensors (issue #190)."""
 
@@ -500,15 +539,15 @@ class TestStoredEnergySensors:
     )
     def test_stored_energy_classification(self, key):
         """Stored energy is ENERGY_STORAGE / MEASUREMENT / kWh."""
-        assert get_device_class_for_sensor(key) == SensorDeviceClass.ENERGY_STORAGE, (
-            f"Failed device_class for {key}"
-        )
-        assert get_state_class_for_sensor(key) == SensorStateClass.MEASUREMENT, (
-            f"Failed state_class for {key}"
-        )
-        assert get_unit_for_sensor(key) == UnitOfEnergy.KILO_WATT_HOUR, (
-            f"Failed unit for {key}"
-        )
+        assert (
+            get_device_class_for_sensor(key) == SensorDeviceClass.ENERGY_STORAGE
+        ), f"Failed device_class for {key}"
+        assert (
+            get_state_class_for_sensor(key) == SensorStateClass.MEASUREMENT
+        ), f"Failed state_class for {key}"
+        assert (
+            get_unit_for_sensor(key) == UnitOfEnergy.KILO_WATT_HOUR
+        ), f"Failed unit for {key}"
 
     def test_stored_energy_not_total_increasing(self):
         """Regression: stored energy must not be classified as a meter."""


### PR DESCRIPTION
## Summary

Option B from the verification follow-up — adds the 4 local-only sensors
identified during live testing as having no overlap with anything the cloud
already exposes. Each was confirmed present in routine telemetry on a real
device (firmware V1.5.8, see #206).

Also lands the small `-1` sentinel filter that fell out of the same
verification (would otherwise turn `t710 = -1` into `-0.001 kWh` nonsense
for batteries without a charging box).

## New sensors

All on the battery device, populated only when the local TCP channel is
connected. They stay unavailable on cloud-only setups, mDNS-blocked
networks, or while the channel is dropped.

| Key | Register | Unit | Class | Notes |
|---|---|---|---|---|
| `head_battery_soc` | `t592` | % | BATTERY | Head unit real SOC — observed 78% while system aggregate (`battery_level`/`batterySoc`) read 84% on the same pack, so not redundant |
| `daily_pv_energy` | `t49` | kWh | ENERGY (total-increasing) | Daily PV generation as the battery sees it (per-battery, distinct from family `daily_yield`) |
| `daily_output_energy` | `t66` | kWh | ENERGY (total-increasing) | Daily energy out of the battery |
| `wifi_rssi` | `t475` | dB | SIGNAL_STRENGTH | Connection-health diagnostic; `EntityCategory.DIAGNOSTIC` |

## RSSI: protocol decoder change

The device sends the RSSI magnitude as a positive int (e.g. `80` for a real
`-80 dB`). The protocol's `t475` decoder now **negates** the raw value so the
sensor renders as plain `dB` with the standard SIGNAL_STRENGTH device class —
no custom display logic, no surprises for users reading the value through
the HA dev tools.

## `-1` sentinel filter

`decode_telemetry` previously only filtered `0xFFFFFFFF`. The live device
also uses `-1` for "no value" on absent modules (`t595=-1` when only
modules 1 & 2 are populated) and missing charging-box fields
(`t710`/`t711`/`t701_4`/`t702_4`). Added `UNSET_VALUES = frozenset({UNSET, -1})`
and switched both `decode_telemetry` and `heater_bits` to use it.

## Tests

```
.venv/bin/python -m pytest tests/ --asyncio-mode=auto
# 278 passed
```

- `+3` protocol cases: `-1` sentinel, `t475` negation, `heater_bits(-1)` ⇒ `[]`
- `+1` translate case: the four new local-only keys
- `+1` helpers test class `TestLocalOnlySensors` checking
  device_class / state_class / unit / entity_category for all four keys
- `head_battery_soc` also added to the existing `test_battery_sensors` parameter list

## Out of scope

- **`t586` heater bitfield → 8 binary sensors** — deferred. Architecturally
  straightforward (the `heater_bits()` helper already splits the field), but
  it spans the binary-sensor platform and adds 8 entities per battery;
  better as its own slice.
- **BMS hardware SOC limit registers** (`t507/t508`, `t509/t510`, …) —
  defer; the cloud poll already populates `hw_soc_min/max` at the family
  level, so there's no urgency.

Builds on #206 (verification log). Part of the #163 epic; closes most of
the "local-only diagnostics" sub-thread of #179.