### PR TITLE
feat(prices): import_price_history service for long-term statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,24 @@ neutrally-priced hours. Each contiguous run of matching hours becomes one
 - Past days are fetched **on demand** when you scroll back in the Calendar
   dashboard. The endpoint's verified horizon is roughly the last 12 months.
 
+#### Backfill price history into long-term statistics (optional)
+
+The calendar shows past blocks the moment you scroll to them, but the
+recorder only starts tracking long-term statistics for the `electricity_price`
+sensor when the integration begins recording. Run the
+`sunlit.import_price_history` service once after install to backfill up to
+~365 days of historical hourly prices onto that sensor's statistics — months
+of price history then appear in the Statistics card on day one:
+
+```yaml
+service: sunlit.import_price_history
+data:
+  days: 365    # optional; default is the full available window (~365)
+```
+
+The service is idempotent (re-running overwrites the same hourly buckets) and
+re-runnable as the available archive grows by one day each calendar day.
+
 **Example automations** (HA's Calendar trigger fires once at event start/end
 with an optional offset):
 

--- a/custom_components/sunlit/__init__.py
+++ b/custom_components/sunlit/__init__.py
@@ -6,11 +6,13 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import voluptuous as vol
 
 from .api_client import SunlitApiClient
 from .const import (
+    ATTR_DAYS,
     CONF_ACCESS_TOKEN,
     CONF_BATTERIES,
     CONF_FAMILIES,
@@ -23,6 +25,7 @@ from .const import (
     OPT_SOC_THRESHOLD_CRITICAL_LOW,
     OPT_SOC_THRESHOLD_HIGH,
     OPT_SOC_THRESHOLD_LOW,
+    SERVICE_IMPORT_PRICE_HISTORY,
 )
 from .coordinators import (
     SunlitDeviceCoordinator,
@@ -33,6 +36,12 @@ from .coordinators import (
 )
 from .event_manager import SunlitEventManager
 from .local.manager import LocalChannelManager
+from .price_statistics import (
+    DEFAULT_DAYS,
+    MAX_DAYS,
+    MIN_DAYS,
+    async_import_all_price_history,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -215,9 +224,48 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Add update listener for options changes
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 
+    _async_register_services(hass)
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
+
+def _async_register_services(hass: HomeAssistant) -> None:
+    """Register integration-wide services (only once across all entries)."""
+    if hass.services.has_service(DOMAIN, SERVICE_IMPORT_PRICE_HISTORY):
+        return
+
+    async def _handle_import_price_history(call: ServiceCall) -> None:
+        """Backfill historical Rabot prices for every family that has a calendar."""
+        days = call.data.get(ATTR_DAYS, DEFAULT_DAYS)
+        coordinators = [
+            family_coords["tariff_calendar"]
+            for entry_data in hass.data.get(DOMAIN, {}).values()
+            for family_coords in entry_data["coordinators"].values()
+            if "tariff_calendar" in family_coords
+        ]
+        if not coordinators:
+            _LOGGER.warning(
+                "sunlit.import_price_history called but no tariff calendar coordinator"
+                " is active — nothing to backfill"
+            )
+            return
+        total = await async_import_all_price_history(hass, coordinators, days)
+        _LOGGER.info("Price history backfill complete: %s rows imported", total)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_IMPORT_PRICE_HISTORY,
+        _handle_import_price_history,
+        schema=vol.Schema(
+            {
+                vol.Optional(ATTR_DAYS, default=DEFAULT_DAYS): vol.All(
+                    vol.Coerce(int), vol.Range(min=MIN_DAYS, max=MAX_DAYS)
+                ),
+            }
+        ),
+    )
 
 
 async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -233,5 +281,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         local_manager = entry_data.get("local_manager")
         if local_manager is not None:
             await local_manager.async_stop()
+
+        # Remove integration-wide services when the last entry is gone.
+        if not hass.data[DOMAIN] and hass.services.has_service(
+            DOMAIN, SERVICE_IMPORT_PRICE_HISTORY
+        ):
+            hass.services.async_remove(DOMAIN, SERVICE_IMPORT_PRICE_HISTORY)
 
     return unload_ok

--- a/custom_components/sunlit/const.py
+++ b/custom_components/sunlit/const.py
@@ -4,6 +4,10 @@ from datetime import timedelta
 
 DOMAIN = "sunlit"
 
+# Services
+SERVICE_IMPORT_PRICE_HISTORY = "import_price_history"
+ATTR_DAYS = "days"
+
 # Integration metadata
 INTEGRATION_NAME = "ha-sunlit"
 GITHUB_URL = "https://github.com/cedricziel/ha-sunlit"

--- a/custom_components/sunlit/manifest.json
+++ b/custom_components/sunlit/manifest.json
@@ -1,6 +1,9 @@
 {
     "domain": "sunlit",
     "name": "SunEnergyXT (previously Sunlit Solar)",
+    "after_dependencies": [
+        "recorder"
+    ],
     "codeowners": [
         "@cedricziel"
     ],

--- a/custom_components/sunlit/price_statistics.py
+++ b/custom_components/sunlit/price_statistics.py
@@ -1,0 +1,182 @@
+"""Backfill historical Rabot price statistics onto the electricity_price sensor.
+
+Companion to ``calendar.py`` — the calendar serves past events on demand from
+``rabot/day/price``, but recorder long-term statistics for the
+``electricity_price`` sensor only start accumulating when the integration
+records them. This module walks the verified backward horizon (~365 days) and
+imports per-hour MEASUREMENT statistics (``mean = min = max = hourly price``)
+onto the entity's own statistic_id via :func:`async_import_statistics`.
+
+The import is idempotent: per-hour buckets are keyed by ``start``, so re-running
+just overwrites the same rows. The service is opt-in (user-invoked) — startup
+stays minimal.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import date, datetime, timedelta
+import logging
+from typing import Any
+
+from homeassistant.components.recorder import DOMAIN as RECORDER_DOMAIN
+from homeassistant.components.recorder.models import StatisticData, StatisticMetaData
+from homeassistant.components.recorder.statistics import async_import_statistics
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
+from .coordinators.tariff_calendar import (
+    MAX_PAST_DAYS,
+    HourlyPrice,
+    SunlitTariffCalendarCoordinator,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# Backfill ceiling (matches the verified horizon of rabot/day/price).
+DEFAULT_DAYS = MAX_PAST_DAYS
+MIN_DAYS = 1
+MAX_DAYS = MAX_PAST_DAYS
+
+# ``mean_type`` (HA 2025.5+) replaced ``has_mean``; stay compatible with the
+# minimum HA version the integration supports.
+try:
+    from homeassistant.components.recorder.models import StatisticMeanType
+
+    _MEAN_META: dict[str, Any] = {"mean_type": StatisticMeanType.ARITHMETIC}
+except ImportError:  # pragma: no cover - HA < 2025.5
+    _MEAN_META = {"has_mean": True}
+
+
+def _clamp_days(value: Any) -> int:
+    """Coerce ``days`` to int and clamp to the supported range."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return DEFAULT_DAYS
+    return max(MIN_DAYS, min(MAX_DAYS, n))
+
+
+def resolve_price_statistic_id(
+    hass: HomeAssistant, family_name: str, family_id: str | int
+) -> str | None:
+    """Resolve the live entity_id for the family's electricity_price sensor.
+
+    Mirrors the user-renameable-entity_id approach already used in #191:
+    look up the entity by stable unique_id rather than constructing a slug.
+    """
+    unique_id = (
+        f"sunlit_{family_name.lower().replace(' ', '_')}_{family_id}_electricity_price"
+    )
+    return er.async_get(hass).async_get_entity_id(SENSOR_DOMAIN, DOMAIN, unique_id)
+
+
+def build_price_statistics(
+    statistic_id: str,
+    daily_prices: dict[date, list[HourlyPrice]],
+) -> tuple[StatisticMetaData, list[StatisticData]]:
+    """Build (metadata, hourly statistic rows) for the price sensor."""
+    metadata = StatisticMetaData(
+        **_MEAN_META,
+        has_sum=False,
+        name=None,  # HA uses the entity's friendly name
+        source=RECORDER_DOMAIN,
+        statistic_id=statistic_id,
+        unit_class=None,
+        unit_of_measurement="ct/kWh",
+    )
+    statistics: list[StatisticData] = []
+    for day in sorted(daily_prices):
+        midnight = dt_util.start_of_local_day(day)
+        for entry in sorted(daily_prices[day], key=lambda p: p.hour):
+            start = midnight + timedelta(hours=entry.hour)
+            price = entry.price_ct_per_kwh
+            statistics.append(
+                StatisticData(start=start, mean=price, min=price, max=price)
+            )
+    return metadata, statistics
+
+
+async def async_collect_price_history(
+    coordinator: SunlitTariffCalendarCoordinator,
+    days: int,
+    *,
+    now: datetime | None = None,
+) -> dict[date, list[HourlyPrice]]:
+    """Walk ``days`` days back, fetching missing days via the coordinator.
+
+    Already-cached days are reused (the calendar's on-demand fetches double as
+    cache warming). Days outside the verified horizon are skipped silently.
+    """
+    if now is None:
+        now = dt_util.now()
+    today = now.date()
+    collected: dict[date, list[HourlyPrice]] = {}
+    # Walk oldest -> newest so the cumulative cache builds naturally.
+    for offset in range(days, 0, -1):
+        day = today - timedelta(days=offset)
+        prices = await coordinator.async_ensure_day(day)
+        if prices:
+            collected[day] = prices
+    return collected
+
+
+async def async_import_family_price_history(
+    hass: HomeAssistant,
+    coordinator: SunlitTariffCalendarCoordinator,
+    days: int = DEFAULT_DAYS,
+) -> int:
+    """Backfill ``electricity_price`` MEASUREMENT statistics for one family.
+
+    Returns the number of hourly statistic rows imported.
+    """
+    statistic_id = resolve_price_statistic_id(
+        hass, coordinator.family_name, coordinator.family_id
+    )
+    if not statistic_id:
+        _LOGGER.warning(
+            "electricity_price entity not registered for %s — skipping backfill",
+            coordinator.family_name,
+        )
+        return 0
+
+    collected = await async_collect_price_history(coordinator, _clamp_days(days))
+    if not collected:
+        _LOGGER.info(
+            "No historical Rabot prices available for %s in the last %s day(s)",
+            coordinator.family_name,
+            days,
+        )
+        return 0
+
+    metadata, statistics = build_price_statistics(statistic_id, collected)
+    async_import_statistics(hass, metadata, statistics)
+    _LOGGER.info(
+        "Imported %s hourly price statistics rows for %s (%s -> %s)",
+        len(statistics),
+        coordinator.family_name,
+        min(collected),
+        max(collected),
+    )
+    return len(statistics)
+
+
+async def async_import_all_price_history(
+    hass: HomeAssistant,
+    coordinators: Iterable[SunlitTariffCalendarCoordinator],
+    days: int = DEFAULT_DAYS,
+) -> int:
+    """Backfill prices for every family that has a tariff coordinator."""
+    total = 0
+    for coordinator in coordinators:
+        try:
+            total += await async_import_family_price_history(hass, coordinator, days)
+        except Exception:
+            _LOGGER.exception(
+                "Failed to import historical price statistics for %s",
+                coordinator.family_name,
+            )
+    return total

--- a/custom_components/sunlit/services.yaml
+++ b/custom_components/sunlit/services.yaml
@@ -1,0 +1,24 @@
+import_price_history:
+  name: Import Rabot price history
+  description: >-
+    Backfill historical Rabot day-ahead electricity prices into Home
+    Assistant's long-term statistics for the family's electricity_price
+    sensor. Useful right after install, so the Statistics card shows months
+    of price history. Idempotent; safe to re-run. Only runs for families
+    that already have a tariff calendar coordinator.
+  fields:
+    days:
+      name: Days
+      description: >-
+        How many days of history to import (max ~365, the verified backward
+        horizon of rabot/day/price).
+        Default is the full available window.
+      example: 90
+      default: 365
+      selector:
+        number:
+          min: 1
+          max: 365
+          step: 1
+          mode: box
+          unit_of_measurement: days

--- a/custom_components/sunlit/strings.json
+++ b/custom_components/sunlit/strings.json
@@ -58,5 +58,17 @@
         }
       }
     }
+  },
+  "services": {
+    "import_price_history": {
+      "name": "Import Rabot price history",
+      "description": "Backfill historical Rabot day-ahead electricity prices into Home Assistant's long-term statistics for the family's electricity_price sensor. Useful right after install, so the Statistics card shows months of price history. Idempotent; safe to re-run.",
+      "fields": {
+        "days": {
+          "name": "Days",
+          "description": "How many days of history to import (max ~365, the verified backward horizon of rabot/day/price). Default is the full available window."
+        }
+      }
+    }
   }
 }

--- a/tests/test_price_statistics.py
+++ b/tests/test_price_statistics.py
@@ -1,0 +1,247 @@
+"""Tests for the Rabot price-history backfill."""
+
+from datetime import UTC, date, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.util import dt as dt_util
+import pytest
+
+from custom_components.sunlit.coordinators.tariff_calendar import HourlyPrice
+from custom_components.sunlit.price_statistics import (
+    DEFAULT_DAYS,
+    MAX_DAYS,
+    MIN_DAYS,
+    _clamp_days,
+    async_collect_price_history,
+    async_import_all_price_history,
+    async_import_family_price_history,
+    build_price_statistics,
+)
+
+# ---------------------------------------------------------------------------
+# _clamp_days
+# ---------------------------------------------------------------------------
+
+
+def test_clamp_days_clamps_below_min():
+    assert _clamp_days(0) == MIN_DAYS
+    assert _clamp_days(-100) == MIN_DAYS
+
+
+def test_clamp_days_clamps_above_max():
+    assert _clamp_days(MAX_DAYS + 50) == MAX_DAYS
+
+
+def test_clamp_days_default_on_garbage():
+    assert _clamp_days("not a number") == DEFAULT_DAYS
+    assert _clamp_days(None) == DEFAULT_DAYS
+
+
+def test_clamp_days_accepts_inrange():
+    assert _clamp_days(30) == 30
+    assert _clamp_days("90") == 90
+
+
+# ---------------------------------------------------------------------------
+# build_price_statistics
+# ---------------------------------------------------------------------------
+
+
+def _prices_for_day(day_offset: int) -> list[HourlyPrice]:
+    return [
+        HourlyPrice(hour=h, price_ct_per_kwh=10.0 + h, avg_ct_per_kwh=15.0, tag="CHEAP")
+        for h in range(24)
+    ]
+
+
+def test_build_price_statistics_one_row_per_hour():
+    """Each hour gets a single MEASUREMENT row with mean=min=max=price."""
+    d = date(2026, 6, 1)
+    daily = {d: _prices_for_day(0)}
+
+    metadata, statistics = build_price_statistics(
+        "sensor.sunlit_garage_34038_electricity_price", daily
+    )
+
+    assert metadata["statistic_id"] == "sensor.sunlit_garage_34038_electricity_price"
+    assert metadata["source"] == "recorder"
+    assert metadata["name"] is None
+    assert metadata["has_sum"] is False
+    assert metadata["unit_of_measurement"] == "ct/kWh"
+
+    assert len(statistics) == 24
+    midnight = dt_util.start_of_local_day(d)
+    assert statistics[0]["start"] == midnight
+    assert statistics[0]["mean"] == 10.0
+    assert statistics[0]["min"] == 10.0
+    assert statistics[0]["max"] == 10.0
+    assert statistics[5]["mean"] == 15.0
+    # Hour-aligned, tz-aware, ascending.
+    starts = [row["start"] for row in statistics]
+    assert all(s.minute == 0 and s.second == 0 for s in starts)
+    assert starts == sorted(starts)
+
+
+def test_build_price_statistics_multiple_days():
+    """Across multiple days, rows are emitted in date+hour order."""
+    d1 = date(2026, 5, 30)
+    d2 = date(2026, 5, 31)
+    statistics = build_price_statistics(
+        "sensor.x", {d2: _prices_for_day(0), d1: _prices_for_day(0)}
+    )[1]
+    assert len(statistics) == 48
+    # First day comes first in the output even though dict iteration is unordered.
+    midnight1 = dt_util.start_of_local_day(d1)
+    midnight2 = dt_util.start_of_local_day(d2)
+    assert statistics[0]["start"] == midnight1
+    assert statistics[24]["start"] == midnight2
+
+
+# ---------------------------------------------------------------------------
+# async_collect_price_history
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_collect_walks_oldest_to_newest():
+    """Walking days N..1 back asks for the right dates in order."""
+    coordinator = MagicMock()
+    requested: list[date] = []
+
+    async def _ensure(day):
+        requested.append(day)
+        return _prices_for_day(0) if day.day % 2 == 0 else []
+
+    coordinator.async_ensure_day = AsyncMock(side_effect=_ensure)
+    pinned = datetime(2026, 6, 5, 12, 0, tzinfo=UTC)
+
+    collected = await async_collect_price_history(coordinator, days=4, now=pinned)
+
+    today = pinned.date()
+    assert requested == [today - timedelta(days=o) for o in (4, 3, 2, 1)]
+    # Only days whose date.day is even got data (per side_effect):
+    # today=2026-06-05 -> days 06-01..06-04, even ones are 06-02 and 06-04.
+    assert set(collected) == {today - timedelta(days=3), today - timedelta(days=1)}
+
+
+@pytest.mark.asyncio
+async def test_collect_empty_when_no_data():
+    coordinator = MagicMock()
+    coordinator.async_ensure_day = AsyncMock(return_value=[])
+    assert await async_collect_price_history(coordinator, days=3) == {}
+
+
+# ---------------------------------------------------------------------------
+# async_import_family_price_history
+# ---------------------------------------------------------------------------
+
+
+def _coord(family_id="34038", family_name="Garage") -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.family_id = family_id
+    coordinator.family_name = family_name
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_import_family_history_resolves_entity_and_imports():
+    """Happy path: resolve entity, collect, build, import."""
+    coordinator = _coord()
+    coordinator.async_ensure_day = AsyncMock(return_value=_prices_for_day(0))
+
+    with (
+        patch(
+            "custom_components.sunlit.price_statistics.resolve_price_statistic_id",
+            return_value="sensor.sunlit_garage_34038_electricity_price",
+        ),
+        patch(
+            "custom_components.sunlit.price_statistics.async_import_statistics"
+        ) as mock_import,
+    ):
+        count = await async_import_family_price_history(
+            MagicMock(), coordinator, days=2
+        )
+
+    assert count == 48  # 2 days x 24 hours
+    mock_import.assert_called_once()
+    metadata, statistics = mock_import.call_args.args[1], mock_import.call_args.args[2]
+    assert metadata["statistic_id"] == "sensor.sunlit_garage_34038_electricity_price"
+    assert len(statistics) == 48
+
+
+@pytest.mark.asyncio
+async def test_import_family_history_skips_when_entity_missing():
+    """No entity_id -> warn + skip, no import call."""
+    coordinator = _coord()
+    coordinator.async_ensure_day = AsyncMock(return_value=_prices_for_day(0))
+
+    with (
+        patch(
+            "custom_components.sunlit.price_statistics.resolve_price_statistic_id",
+            return_value=None,
+        ),
+        patch(
+            "custom_components.sunlit.price_statistics.async_import_statistics"
+        ) as mock_import,
+    ):
+        count = await async_import_family_price_history(
+            MagicMock(), coordinator, days=5
+        )
+
+    assert count == 0
+    mock_import.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_import_family_history_skips_when_no_data_in_window():
+    """All days return empty -> nothing imported."""
+    coordinator = _coord()
+    coordinator.async_ensure_day = AsyncMock(return_value=[])
+
+    with (
+        patch(
+            "custom_components.sunlit.price_statistics.resolve_price_statistic_id",
+            return_value="sensor.x_electricity_price",
+        ),
+        patch(
+            "custom_components.sunlit.price_statistics.async_import_statistics"
+        ) as mock_import,
+    ):
+        count = await async_import_family_price_history(
+            MagicMock(), coordinator, days=7
+        )
+
+    assert count == 0
+    mock_import.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# async_import_all_price_history
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_import_all_aggregates_across_families():
+    """Total rows = sum of per-family imports; per-family errors don't abort."""
+    good = _coord(family_id="1", family_name="Family A")
+    good.async_ensure_day = AsyncMock(return_value=_prices_for_day(0))
+
+    broken = _coord(family_id="2", family_name="Family B")
+    broken.async_ensure_day = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with (
+        patch(
+            "custom_components.sunlit.price_statistics.resolve_price_statistic_id",
+            side_effect=lambda hass, name, fid: f"sensor.x_{fid}",
+        ),
+        patch(
+            "custom_components.sunlit.price_statistics.async_import_statistics"
+        ) as mock_import,
+    ):
+        total = await async_import_all_price_history(
+            MagicMock(), [good, broken], days=1
+        )
+
+    assert total == 24  # only the good family contributed
+    # One import for the good family; broken family's exception was swallowed.
+    assert mock_import.call_count == 1


### PR DESCRIPTION
Stacked on #213 (tariff calendar). Base will retarget to \`main\` once #213 merges.

## What it adds
An opt-in service that backfills historical Rabot day-ahead prices into HA's long-term statistics for the family's \`electricity_price\` sensor — so the Statistics card shows months of price history immediately, instead of starting from blank on install.

\`\`\`yaml
service: sunlit.import_price_history
data:
  days: 365   # default and ceiling
\`\`\`

## Why it's separate from the calendar (#213)
The calendar already serves past blocks on demand via \`async_get_events\` (no recorder involved) — that's the visual history. The recorder's long-term statistics, however, only start when the integration starts. This service decouples those two concerns: zero startup cost, opt-in for the durable stats.

## How it works
- Walks \`today − days … today − 1\` day by day; for each day calls \`SunlitTariffCalendarCoordinator.async_ensure_day(day)\` (which double-caches the calendar). Empty days are skipped silently.
- Builds one \`StatisticData(start, mean=min=max=price)\` per hour and calls \`async_import_statistics\` with \`source=\"recorder\"\`, \`mean_type=ARITHMETIC\`, \`has_sum=False\`, unit \`ct/kWh\`, statistic_id resolved from the entity registry by stable unique_id.
- Idempotent: per-hour buckets are keyed by \`start\`, so re-runs overwrite the same rows. Re-runnable as the archive grows by a day each calendar day.

## Files
- \`price_statistics.py\` — \`_clamp_days\`, \`resolve_price_statistic_id\`, \`build_price_statistics\` (pure), \`async_collect_price_history\`, \`async_import_family_price_history\`, \`async_import_all_price_history\`.
- \`__init__.py\` — registers \`sunlit.import_price_history\` once across entries (voluptuous schema clamps \`days\` to 1..~365); removes it when the last entry unloads.
- \`manifest.json\` — \`after_dependencies: recorder\`.
- \`services.yaml\` + \`strings.json\` — service description with \`days\` number selector.
- README — short section under the tariff-calendar docs.

## Tests
- \`test_price_statistics.py\` — 12 tests covering clamp behavior, the pure \`build_price_statistics\` shape (metadata fields, hour alignment, multi-day ordering), the oldest→newest collect walk, the entity-missing/empty-window skips, and multi-family aggregation with per-family errors swallowed.

**330 tests pass** (313 baseline + 5 from PR A + 12 from this PR); coverage 77.8%; ruff/isort clean.