### PR TITLE
fix(family): coerce charging-box booleans to False on null

### DIFF
--- a/custom_components/sunlit/coordinators/family.py
+++ b/custom_components/sunlit/coordinators/family.py
@@ -373,24 +373,29 @@ class SunlitFamilyCoordinator(DataUpdateCoordinator):
                 if inverter_sn_list:
                     family_data["inverter_sn_list"] = ", ".join(inverter_sn_list)
 
-                # Binary flags
-                family_data["ev3600_auto_strategy_exist"] = charging_box_data.get(
-                    "ev3600AutoStrategyExist", False
+                # Binary flags. Coerce via bool() because the cloud emits
+                # explicit `null` for flags that haven't been initialised
+                # (e.g. tariffStrategyExist before a tariff strategy is
+                # configured). dict.get(key, False) returns the cloud's None
+                # in that case, which surfaces as `unknown` in HA rather
+                # than `off`. bool(None) collapses both branches to False.
+                family_data["ev3600_auto_strategy_exist"] = bool(
+                    charging_box_data.get("ev3600AutoStrategyExist")
                 )
-                family_data["ev3600_auto_strategy_running"] = charging_box_data.get(
-                    "ev3600AutoStrategyRunning", False
+                family_data["ev3600_auto_strategy_running"] = bool(
+                    charging_box_data.get("ev3600AutoStrategyRunning")
                 )
-                family_data["tariff_strategy_exist"] = charging_box_data.get(
-                    "tariffStrategyExist", False
+                family_data["tariff_strategy_exist"] = bool(
+                    charging_box_data.get("tariffStrategyExist")
                 )
-                family_data["enable_local_smart_strategy"] = charging_box_data.get(
-                    "enableLocalSmartStrategy", False
+                family_data["enable_local_smart_strategy"] = bool(
+                    charging_box_data.get("enableLocalSmartStrategy")
                 )
-                family_data["ac_couple_enabled"] = charging_box_data.get(
-                    "acCoupleEnabled", False
+                family_data["ac_couple_enabled"] = bool(
+                    charging_box_data.get("acCoupleEnabled")
                 )
-                family_data["charging_box_boost_on"] = charging_box_data.get(
-                    "boostOn", False
+                family_data["charging_box_boost_on"] = bool(
+                    charging_box_data.get("boostOn")
                 )
         except Exception as err:
             _LOGGER.debug("Could not fetch charging box strategy: %s", err)

--- a/tests/test_family_coordinator.py
+++ b/tests/test_family_coordinator.py
@@ -340,3 +340,63 @@ async def test_family_coordinator_positive_daily_values_unchanged(
     # Verify positive values unchanged
     assert family_data["daily_yield"] == 25.3
     assert family_data["daily_earnings"] == 5.2
+
+
+async def test_charging_box_strategy_null_booleans_normalized_to_false(
+    hass: HomeAssistant,
+    enable_custom_integrations,
+    space_index_response,
+):
+    """Cloud returns explicit ``null`` for uninitialised boolean flags.
+
+    Real-world ``chargingBoxCheckStrategy`` responses include
+    ``"tariffStrategyExist": null`` when no tariff strategy has been
+    configured yet (see fixtures/api/charging_box_strategy_family_10001.json).
+    ``dict.get(key, False)`` returns the cloud's None in that case, which
+    surfaces as ``unknown`` in HA instead of ``off``. The coordinator must
+    coerce these to a proper ``False`` so the binary sensors report a
+    deterministic state.
+    """
+    api_client = AsyncMock()
+    api_client.fetch_space_index.return_value = space_index_response["content"]
+    api_client.fetch_device_list.return_value = []
+    api_client.fetch_space_soc.return_value = {
+        "hwSbmsLimitedDiscSocMin": 10,
+        "hwSbmsLimitedChgSocMax": 95,
+    }
+    api_client.fetch_space_current_strategy.return_value = {
+        "strategy": "SELF_CONSUMPTION"
+    }
+    # Mirror the shape of the captured production response: real booleans
+    # for most flags, explicit None for the uninitialised tariff flag.
+    api_client.get_charging_box_strategy.return_value = {
+        "ev3600AutoStrategyExist": False,
+        "ev3600AutoStrategyRunning": False,
+        "tariffStrategyExist": None,
+        "enableLocalSmartStrategy": False,
+        "acCoupleEnabled": False,
+        "boostOn": False,
+    }
+
+    coordinator = SunlitFamilyCoordinator(
+        hass,
+        api_client,
+        "34038",
+        "Test Family",
+    )
+
+    data = await coordinator._async_update_data()
+    family_data = data["family"]
+
+    # Every boolean flag must be a real bool — never None.
+    for key in (
+        "ev3600_auto_strategy_exist",
+        "ev3600_auto_strategy_running",
+        "tariff_strategy_exist",
+        "enable_local_smart_strategy",
+        "ac_couple_enabled",
+        "charging_box_boost_on",
+    ):
+        assert family_data[key] is False, (
+            f"{key} should be False, got {family_data[key]!r}"
+        )


### PR DESCRIPTION
## Summary

- Wrap the six boolean reads in `_fetch_charging_box_strategy` with `bool()` so that the cloud's explicit `null` for uninitialised flags (most visibly `tariffStrategyExist`) collapses to `False` instead of leaking through as `None`.
- Add a regression test that mirrors the captured production payload (`tests/fixtures/api/charging_box_strategy_family_10001.json` already carried `"tariffStrategyExist": null`) and asserts every boolean lands as a real `False`.

## Why

`dict.get(key, default)` only returns the default when the key is **absent** — not when it's present with a `None` value. The cloud emits `"tariffStrategyExist": null` for spaces that have never pushed a tariff strategy, so the coordinator stored `None` and the `family_binary_sensor` returned `None` → HA surfaced `unknown` instead of `off`. The five sibling boolean flags share the same pattern and are fixed defensively.

The non-boolean fields in the same block (`ev3600AutoStrategyMode`, `storageStrategy`, `normalChargeBoxMode`, `inverterSn`) stay nullable on purpose — they back sensors/string entities where `None` is a valid state.

## Test plan

- [x] `make lint` clean
- [x] `pytest tests/test_family_coordinator.py -v --asyncio-mode=auto` — 7/7 passed (existing 6 + new regression test)
- [ ] After merge: existing `binary_sensor.*_tariff_strategy_exists` entities transition from `unknown` → `off` on the next family-coordinator refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed some charging-box status fields so missing values now appear as **false** instead of unknown/blank states.
  * Improved consistency in family data updates by normalizing several binary flags more reliably.

* **Tests**
  * Added coverage to verify these fields are handled correctly when the source data contains null values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->