### PR TITLE
chore(deps-dev): pin aiohttp<3.14 until aioresponses ships fix

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,20 @@ pytest
 pytest-asyncio<2.0.0
 pytest-cov
 pytest-timeout
+# aiohttp 3.14 added a required `stream_writer` kwarg to
+# ClientResponse.__init__, which every released aioresponses still calls
+# without — every aioresponses-based test then raises:
+#   TypeError: ClientResponse.__init__() missing 1 required keyword-only
+#   argument: 'stream_writer'
+# Upstream fix: https://github.com/pnuckowski/aioresponses/pull/288 (issue
+# #289), not yet released.
+#
+# Constrain aiohttp here in dev deps because pytest-homeassistant-custom-
+# component pulls HA 2026.7.0b2 in CI, which accepts aiohttp 3.14. HA core
+# 2026.6.4 in requirements.txt already pins aiohttp<3.14 transitively, so
+# this only affects the test env. Drop once an aioresponses release with
+# the upstream fix ships.
+aiohttp<3.14
 aioresponses
 pytest-homeassistant-custom-component
 


### PR DESCRIPTION
## Summary

Pin `aiohttp<3.14` in `requirements-dev.txt`. aiohttp 3.14 added a required `stream_writer` kwarg to `ClientResponse.__init__`; every released `aioresponses` (verified against 0.7.8 and 0.7.9) still calls `ClientResponse(...)` without it, so any aioresponses-based test crashes with `TypeError`. Upstream fix sits in [aioresponses#288](https://github.com/pnuckowski/aioresponses/pull/288) (issue [#289](https://github.com/pnuckowski/aioresponses/issues/289)) and is not yet released.

## Why a dev pin and not a main pin

HA core 2026.6.4 already constrains `aiohttp<3.14` transitively, so production environments are unaffected. The breakage only surfaces in CI because `pytest-homeassistant-custom-component-0.13.342` pulls HA `2026.7.0b2` on top of `requirements.txt`, which accepts aiohttp 3.14 and resolves to 3.14.1.

## Verification

| aiohttp | aioresponses | Result |
|---|---|---|
| 3.13.5 | 0.7.8 | ✅ tests pass (initial local) |
| 3.13.5 | 0.7.9 | ✅ tests pass (verified after install) |
| 3.14.1 | 0.7.8 | ❌ TypeError (CI on this PR before pin) |
| 3.14.1 | 0.7.9 | ❌ TypeError (CI on #230) |

Root cause is the aiohttp major-minor bump, not aioresponses. Earlier draft of this PR excluded only 0.7.9, which was the wrong diagnosis — corrected via force-push to a single, accurate constraint.

## Test plan

- [x] Local `pytest tests/test_simple_api_client.py` with aiohttp 3.13.5 + aioresponses 0.7.9 → 3/3 passed
- [ ] Verify `Test Python 3.14` on this branch is green
- [ ] After merge, rebase #230 onto main and confirm CI is green there