### PR TITLE
fix: create entities when their data appears, not only at setup

### DIFF
--- a/custom_components/sunlit/binary_sensor.py
+++ b/custom_components/sunlit/binary_sensor.py
@@ -6,6 +6,7 @@ import logging
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
+    BinarySensorEntity,
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -13,6 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
+from .dynamic_entities import async_setup_dynamic_entities
 from .entities.device_binary_sensor import SunlitDeviceBinarySensor
 from .entities.family_binary_sensor import SunlitFamilyBinarySensor
 
@@ -161,72 +163,106 @@ async def async_setup_entry(
         # Fallback for old structure
         coordinators = integration_data
 
-    sensors = []
+    def build_sensors(created_keys: set[str]) -> list[BinarySensorEntity]:
+        """Build binary sensors whose keys have appeared but have no entity yet.
 
-    # Process multiple family coordinators
-    for family_id, coordinator_set in coordinators.items():
-        # Use the new specialized coordinators
-        if not isinstance(coordinator_set, dict):
-            # Handle old coordinator structure for backwards compatibility
-            _LOGGER.warning(
-                "Old coordinator structure detected, skipping family %s", family_id
-            )
-            continue
+        Both loops below are driven by keys the cloud actually reported, so a
+        device that was offline at startup contributes nothing on the first
+        pass and gets its sensors on a later coordinator update instead.
+        """
+        sensors: list[BinarySensorEntity] = []
 
-        family_coordinator = coordinator_set.get("family")
-        device_coordinator = coordinator_set.get("device")
+        # Process multiple family coordinators
+        for family_id, coordinator_set in coordinators.items():
+            # Use the new specialized coordinators
+            if not isinstance(coordinator_set, dict):
+                # Handle old coordinator structure for backwards compatibility
+                _LOGGER.warning(
+                    "Old coordinator structure detected, skipping family %s", family_id
+                )
+                continue
 
-        # Skip if essential coordinators are missing
-        if not family_coordinator or not device_coordinator:
-            _LOGGER.warning("Missing essential coordinators for family %s", family_id)
-            continue
+            family_coordinator = coordinator_set.get("family")
+            device_coordinator = coordinator_set.get("device")
 
-        # Create family binary sensors
-        if family_coordinator.data and "family" in family_coordinator.data:
-            for key, config in FAMILY_BINARY_SENSORS.items():
-                if key in family_coordinator.data["family"]:
-                    sensor_description = BinarySensorEntityDescription(
-                        key=key,
-                        name=config["name"],
-                        device_class=config.get("device_class"),
-                    )
-                    sensor = SunlitFamilyBinarySensor(
-                        coordinator=family_coordinator,
-                        description=sensor_description,
-                        entry_id=config_entry.entry_id,
-                        family_id=family_coordinator.family_id,
-                        family_name=family_coordinator.family_name,
-                        icon=config.get("icon"),
-                    )
-                    sensors.append(sensor)
+            # Skip if essential coordinators are missing
+            if not family_coordinator or not device_coordinator:
+                _LOGGER.warning(
+                    "Missing essential coordinators for family %s", family_id
+                )
+                continue
 
-        # Create device binary sensors
-        if device_coordinator.data and "devices" in device_coordinator.data:
-            for device_id, device_data in device_coordinator.data["devices"].items():
-                if (
-                    device_coordinator.devices
-                    and device_id in device_coordinator.devices
-                ):
-                    device_info = device_coordinator.devices[device_id]
+            # Create family binary sensors
+            if family_coordinator.data and "family" in family_coordinator.data:
+                for key, config in FAMILY_BINARY_SENSORS.items():
+                    if key in family_coordinator.data["family"]:
+                        entity_key = f"{family_id}:family:{key}"
+                        if entity_key in created_keys:
+                            continue
+                        created_keys.add(entity_key)
 
-                    for key, config in DEVICE_BINARY_SENSORS.items():
-                        if key in device_data:
-                            sensor_description = BinarySensorEntityDescription(
-                                key=key,
-                                name=config["name"],
-                                device_class=config.get("device_class"),
-                            )
-                            sensor = SunlitDeviceBinarySensor(
-                                coordinator=device_coordinator,
-                                description=sensor_description,
-                                entry_id=config_entry.entry_id,
-                                family_id=device_coordinator.family_id,
-                                family_name=device_coordinator.family_name,
-                                device_id=device_id,
-                                device_info_data=device_info,
-                                icon=config.get("icon"),
-                                inverted=config.get("inverted", False),
-                            )
-                            sensors.append(sensor)
+                        sensor_description = BinarySensorEntityDescription(
+                            key=key,
+                            name=config["name"],
+                            device_class=config.get("device_class"),
+                        )
+                        sensor = SunlitFamilyBinarySensor(
+                            coordinator=family_coordinator,
+                            description=sensor_description,
+                            entry_id=config_entry.entry_id,
+                            family_id=family_coordinator.family_id,
+                            family_name=family_coordinator.family_name,
+                            icon=config.get("icon"),
+                        )
+                        sensors.append(sensor)
 
-    async_add_entities(sensors, True)
+            # Create device binary sensors
+            if device_coordinator.data and "devices" in device_coordinator.data:
+                for device_id, device_data in device_coordinator.data[
+                    "devices"
+                ].items():
+                    if (
+                        device_coordinator.devices
+                        and device_id in device_coordinator.devices
+                    ):
+                        device_info = device_coordinator.devices[device_id]
+
+                        for key, config in DEVICE_BINARY_SENSORS.items():
+                            if key in device_data:
+                                entity_key = f"{family_id}:{device_id}:{key}"
+                                if entity_key in created_keys:
+                                    continue
+                                created_keys.add(entity_key)
+
+                                sensor_description = BinarySensorEntityDescription(
+                                    key=key,
+                                    name=config["name"],
+                                    device_class=config.get("device_class"),
+                                )
+                                sensor = SunlitDeviceBinarySensor(
+                                    coordinator=device_coordinator,
+                                    description=sensor_description,
+                                    entry_id=config_entry.entry_id,
+                                    family_id=device_coordinator.family_id,
+                                    family_name=device_coordinator.family_name,
+                                    device_id=device_id,
+                                    device_info_data=device_info,
+                                    icon=config.get("icon"),
+                                    inverted=config.get("inverted", False),
+                                )
+                                sensors.append(sensor)
+
+        return sensors
+
+    platform_coordinators: list = []
+    for coordinator_set in coordinators.values():
+        if isinstance(coordinator_set, dict):
+            platform_coordinators.append(coordinator_set.get("family"))
+            platform_coordinators.append(coordinator_set.get("device"))
+
+    async_setup_dynamic_entities(
+        config_entry,
+        platform_coordinators,
+        async_add_entities,
+        build_sensors,
+    )

--- a/custom_components/sunlit/dynamic_entities.py
+++ b/custom_components/sunlit/dynamic_entities.py
@@ -1,0 +1,54 @@
+"""Create platform entities as data becomes available, not only at setup.
+
+Coordinator payloads are snapshots of what the cloud reported at that moment.
+A device that is offline while Home Assistant starts contributes no keys, so
+platforms that derive their entities from those keys would create nothing for
+it — and, because setup runs exactly once, would never create anything later
+either. The entity then lingers in the registry as ``restored``/unavailable
+until the config entry is reloaded by hand.
+
+The helper here keeps that data-driven behaviour (only entities whose hardware
+actually reports are created, so systems without an EV3600 or charging box stay
+clean) while re-running the builder whenever a coordinator publishes new data.
+"""
+
+from collections.abc import Callable, Iterable
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+
+@callback
+def async_setup_dynamic_entities[EntityT: Entity](
+    config_entry: ConfigEntry,
+    coordinators: Iterable[DataUpdateCoordinator | None],
+    async_add_entities: AddEntitiesCallback,
+    build_entities: Callable[[set[str]], list[EntityT]],
+    update_before_add: bool = True,
+) -> None:
+    """Add entities now and again whenever a coordinator reports new data.
+
+    ``build_entities`` receives the set of keys that have already been created
+    and must return only the entities missing from it, registering their keys as
+    it goes. Keys must be stable across calls (device id, sensor key, module
+    number) so an entity is never created twice.
+    """
+    created_keys: set[str] = set()
+
+    @callback
+    def _async_add_missing_entities() -> None:
+        new_entities = build_entities(created_keys)
+        if new_entities:
+            async_add_entities(new_entities, update_before_add)
+
+    for coordinator in coordinators:
+        if coordinator is None:
+            continue
+        config_entry.async_on_unload(
+            coordinator.async_add_listener(_async_add_missing_entities)
+        )
+
+    _async_add_missing_entities()

--- a/custom_components/sunlit/dynamic_entities.py
+++ b/custom_components/sunlit/dynamic_entities.py
@@ -13,12 +13,15 @@ clean) while re-running the builder whenever a coordinator publishes new data.
 """
 
 from collections.abc import Callable, Iterable
+import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @callback
@@ -40,7 +43,14 @@ def async_setup_dynamic_entities[EntityT: Entity](
 
     @callback
     def _async_add_missing_entities() -> None:
-        new_entities = build_entities(created_keys)
+        # Coordinators call their listeners directly, so an exception escaping
+        # here would abort the remaining listeners for that update. A malformed
+        # payload must not take the rest of the integration down with it.
+        try:
+            new_entities = build_entities(created_keys)
+        except Exception:
+            _LOGGER.exception("Error building entities for %s", config_entry.title)
+            return
         if new_entities:
             async_add_entities(new_entities, update_before_add)
 

--- a/custom_components/sunlit/sensor.py
+++ b/custom_components/sunlit/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.sensor import SensorEntityDescription
+from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -22,6 +22,7 @@ from .const import (
     INVERTER_SENSORS,
     METER_SENSORS,
 )
+from .dynamic_entities import async_setup_dynamic_entities
 from .entities.battery_module_sensor import SunlitBatteryModuleSensor
 from .entities.battery_sensor import SunlitBatterySensor
 from .entities.family_sensor import SunlitFamilySensor
@@ -65,143 +66,199 @@ async def async_setup_entry(
         # Fallback for old structure
         coordinators = integration_data
 
-    sensors = []
+    def build_sensors(created_keys: set[str]) -> list[SensorEntity]:
+        """Build sensors for data that has appeared but has no entity yet.
 
-    # Process multiple family coordinators
-    for family_id, coordinator_set in coordinators.items():
-        # Use the new specialized coordinators
-        if not isinstance(coordinator_set, dict):
-            # Handle old coordinator structure for backwards compatibility
-            _LOGGER.warning(
-                "Old coordinator structure detected, skipping family %s", family_id
-            )
-            continue
+        Family keys and device lists come from coordinator snapshots, so a
+        device that is offline while Home Assistant starts contributes
+        nothing on the first pass; its sensors are created on a later
+        coordinator update instead of never.
+        """
+        sensors: list[SensorEntity] = []
 
-        family_coordinator = coordinator_set.get("family")
-        device_coordinator = coordinator_set.get("device")
-        strategy_coordinator = coordinator_set.get("strategy")
-        mppt_coordinator = coordinator_set.get("mppt")
+        for family_id, coordinator_set in coordinators.items():
+            # Use the new specialized coordinators
+            if not isinstance(coordinator_set, dict):
+                # Handle old coordinator structure for backwards compatibility
+                _LOGGER.warning(
+                    "Old coordinator structure detected, skipping family %s", family_id
+                )
+                continue
 
-        # Skip if essential coordinators are missing
-        if not family_coordinator or not device_coordinator:
-            _LOGGER.warning("Missing essential coordinators for family %s", family_id)
-            continue
+            family_coordinator = coordinator_set.get("family")
+            device_coordinator = coordinator_set.get("device")
+            strategy_coordinator = coordinator_set.get("strategy")
+            mppt_coordinator = coordinator_set.get("mppt")
 
-        if family_coordinator.data:
-            # Create family aggregate sensors from family coordinator
-            if "family" in family_coordinator.data:
-                # Skip binary sensor fields (they're handled by binary_sensor platform)
-                skip_fields = {"has_fault", "battery_full"}
-                family_data = family_coordinator.data["family"]
+            # Skip if essential coordinators are missing
+            if not family_coordinator or not device_coordinator:
+                _LOGGER.warning(
+                    "Missing essential coordinators for family %s", family_id
+                )
+                continue
 
-                # Add strategy data if available
-                if (
-                    strategy_coordinator
-                    and strategy_coordinator.data
-                    and "strategy" in strategy_coordinator.data
-                ):
-                    family_data.update(strategy_coordinator.data["strategy"])
+            if family_coordinator.data:
+                # Create family aggregate sensors from family coordinator
+                if "family" in family_coordinator.data:
+                    # Skip binary sensor fields (they're handled by binary_sensor platform)
+                    skip_fields = {"has_fault", "battery_full"}
+                    family_data = family_coordinator.data["family"]
 
-                # Add the family-level MPPT energy total if available.
-                # (mppt_coordinator.data["mppt_energy"] is keyed by device id and
-                # feeds the per-device/module sensors, not family sensors.)
-                if (
-                    mppt_coordinator
-                    and mppt_coordinator.data
-                    and "total_mppt_energy" in mppt_coordinator.data
-                ):
-                    family_data["total_mppt_energy"] = mppt_coordinator.data[
-                        "total_mppt_energy"
-                    ]
-
-                # Add device aggregates if available
-                if (
-                    device_coordinator
-                    and device_coordinator.data
-                    and "aggregates" in device_coordinator.data
-                ):
-                    family_data.update(device_coordinator.data["aggregates"])
-
-                for key in family_data:
-                    if key in FAMILY_SENSORS and key not in skip_fields:
-                        sensor_description = build_sensor_description(
-                            key, FAMILY_SENSORS[key]
-                        )
-                        # Use appropriate coordinator based on data source
-                        if key in [
-                            "last_strategy_type",
-                            "last_strategy_change",
-                            "last_strategy_status",
-                            "strategy_changes_today",
-                            "strategy_history",
-                        ]:
-                            coord = (
-                                strategy_coordinator
-                                if strategy_coordinator
-                                else family_coordinator
-                            )
-                        elif "mppt" in key and "energy" in key:
-                            coord = (
-                                mppt_coordinator
-                                if mppt_coordinator
-                                else family_coordinator
-                            )
-                        elif key in [
-                            "total_solar_power",
-                            "total_solar_energy",
-                            "total_grid_export_energy",
-                            "daily_grid_export_energy",
-                        ]:
-                            # These aggregates come from device coordinator only
-                            # Don't fall back to family coordinator as it doesn't have these keys
-                            coord = device_coordinator
-                        else:
-                            coord = family_coordinator
-
-                        sensor = SunlitFamilySensor(
-                            coordinator=coord,
-                            description=sensor_description,
-                            entry_id=config_entry.entry_id,
-                            family_id=family_coordinator.family_id,
-                            family_name=family_coordinator.family_name,
-                        )
-                        # Set icon if available
-                        icon = get_icon_for_sensor(key)
-                        if icon:
-                            sensor._attr_icon = icon
-                        sensors.append(sensor)
-
-            # Create individual device sensors from device coordinator
-            if device_coordinator.data and "devices" in device_coordinator.data:
-                for device_id, device_data in device_coordinator.data[
-                    "devices"
-                ].items():
+                    # Add strategy data if available
                     if (
-                        device_coordinator.devices
-                        and device_id in device_coordinator.devices
+                        strategy_coordinator
+                        and strategy_coordinator.data
+                        and "strategy" in strategy_coordinator.data
                     ):
-                        device_info = device_coordinator.devices[device_id]
-                        device_type = device_info.get("deviceType")
+                        family_data.update(strategy_coordinator.data["strategy"])
 
-                        # Determine which sensors to create based on device type
-                        sensor_map = {}
-                        if device_type in [DEVICE_TYPE_METER, DEVICE_TYPE_METER_PRO]:
-                            sensor_map = METER_SENSORS
-                        elif device_type in [
-                            DEVICE_TYPE_INVERTER,
-                            DEVICE_TYPE_INVERTER_SOLAR,
-                        ]:
-                            sensor_map = INVERTER_SENSORS
-                        elif device_type == DEVICE_TYPE_BATTERY:
-                            sensor_map = BATTERY_SENSORS
+                    # Add the family-level MPPT energy total if available.
+                    # (mppt_coordinator.data["mppt_energy"] is keyed by device id and
+                    # feeds the per-device/module sensors, not family sensors.)
+                    if (
+                        mppt_coordinator
+                        and mppt_coordinator.data
+                        and "total_mppt_energy" in mppt_coordinator.data
+                    ):
+                        family_data["total_mppt_energy"] = mppt_coordinator.data[
+                            "total_mppt_energy"
+                        ]
 
-                        # Create ALL sensors defined for this device type
-                        # This ensures sensors are created even if data is not yet available
-                        # Skip binary sensor fields (handled by binary_sensor platform)
-                        skip_device_fields = {"fault", "off"}
-                        for key, name in sensor_map.items():
-                            if key not in skip_device_fields:
-                                sensor_description = build_sensor_description(key, name)
+                    # Add device aggregates if available
+                    if (
+                        device_coordinator
+                        and device_coordinator.data
+                        and "aggregates" in device_coordinator.data
+                    ):
+                        family_data.update(device_coordinator.data["aggregates"])
+
+                    for key in family_data:
+                        if key in FAMILY_SENSORS and key not in skip_fields:
+                            entity_key = f"{family_id}:family:{key}"
+                            if entity_key in created_keys:
+                                continue
+                            created_keys.add(entity_key)
+
+                            sensor_description = build_sensor_description(
+                                key, FAMILY_SENSORS[key]
+                            )
+                            # Use appropriate coordinator based on data source
+                            if key in [
+                                "last_strategy_type",
+                                "last_strategy_change",
+                                "last_strategy_status",
+                                "strategy_changes_today",
+                                "strategy_history",
+                            ]:
+                                coord = (
+                                    strategy_coordinator
+                                    if strategy_coordinator
+                                    else family_coordinator
+                                )
+                            elif "mppt" in key and "energy" in key:
+                                coord = (
+                                    mppt_coordinator
+                                    if mppt_coordinator
+                                    else family_coordinator
+                                )
+                            elif key in [
+                                "total_solar_power",
+                                "total_solar_energy",
+                                "total_grid_export_energy",
+                                "daily_grid_export_energy",
+                            ]:
+                                # These aggregates come from device coordinator only
+                                # Don't fall back to family coordinator as it doesn't have these keys
+                                coord = device_coordinator
+                            else:
+                                coord = family_coordinator
+
+                            sensor = SunlitFamilySensor(
+                                coordinator=coord,
+                                description=sensor_description,
+                                entry_id=config_entry.entry_id,
+                                family_id=family_coordinator.family_id,
+                                family_name=family_coordinator.family_name,
+                            )
+                            # Set icon if available
+                            icon = get_icon_for_sensor(key)
+                            if icon:
+                                sensor._attr_icon = icon
+                            sensors.append(sensor)
+
+                # Create individual device sensors from device coordinator
+                if device_coordinator.data and "devices" in device_coordinator.data:
+                    for device_id, device_data in device_coordinator.data[
+                        "devices"
+                    ].items():
+                        if (
+                            device_coordinator.devices
+                            and device_id in device_coordinator.devices
+                        ):
+                            device_info = device_coordinator.devices[device_id]
+                            device_type = device_info.get("deviceType")
+
+                            # Determine which sensors to create based on device type
+                            sensor_map = {}
+                            if device_type in [
+                                DEVICE_TYPE_METER,
+                                DEVICE_TYPE_METER_PRO,
+                            ]:
+                                sensor_map = METER_SENSORS
+                            elif device_type in [
+                                DEVICE_TYPE_INVERTER,
+                                DEVICE_TYPE_INVERTER_SOLAR,
+                            ]:
+                                sensor_map = INVERTER_SENSORS
+                            elif device_type == DEVICE_TYPE_BATTERY:
+                                sensor_map = BATTERY_SENSORS
+
+                            # Create ALL sensors defined for this device type
+                            # This ensures sensors are created even if data is not yet available
+                            # Skip binary sensor fields (handled by binary_sensor platform)
+                            skip_device_fields = {"fault", "off"}
+                            for key, name in sensor_map.items():
+                                if key not in skip_device_fields:
+                                    entity_key = f"{family_id}:{device_id}:{key}"
+                                    if entity_key in created_keys:
+                                        continue
+                                    created_keys.add(entity_key)
+
+                                    sensor_description = build_sensor_description(
+                                        key, name
+                                    )
+                                    # Pass mppt_coordinator for battery devices
+                                    extra_kwargs = {}
+                                    if device_type == DEVICE_TYPE_BATTERY:
+                                        extra_kwargs["mppt_coordinator"] = (
+                                            mppt_coordinator
+                                        )
+
+                                    sensor = create_device_sensor(
+                                        device_type=device_type,
+                                        coordinator=device_coordinator,
+                                        description=sensor_description,
+                                        entry_id=config_entry.entry_id,
+                                        family_id=device_coordinator.family_id,
+                                        family_name=device_coordinator.family_name,
+                                        device_id=device_id,
+                                        device_info_data=device_info,
+                                        **extra_kwargs,
+                                    )
+                                    # Set icon if available
+                                    icon = get_icon_for_sensor(key, device_type)
+                                    if icon:
+                                        sensor._attr_icon = icon
+                                    sensors.append(sensor)
+
+                            # Always add status sensor for all devices (text state)
+                            status_key = f"{family_id}:{device_id}:status"
+                            if status_key not in created_keys:
+                                created_keys.add(status_key)
+                                sensor_description = SensorEntityDescription(
+                                    key="status",
+                                    name="Status",
+                                )
                                 # Pass mppt_coordinator for battery devices
                                 extra_kwargs = {}
                                 if device_type == DEVICE_TYPE_BATTERY:
@@ -218,79 +275,78 @@ async def async_setup_entry(
                                     device_info_data=device_info,
                                     **extra_kwargs,
                                 )
-                                # Set icon if available
-                                icon = get_icon_for_sensor(key, device_type)
-                                if icon:
-                                    sensor._attr_icon = icon
+                                # Set status icon
+                                sensor._attr_icon = "mdi:information-outline"
                                 sensors.append(sensor)
 
-                        # Always add status sensor for all devices (text state)
-                        sensor_description = SensorEntityDescription(
-                            key="status",
-                            name="Status",
-                        )
-                        # Pass mppt_coordinator for battery devices
-                        extra_kwargs = {}
-                        if device_type == DEVICE_TYPE_BATTERY:
-                            extra_kwargs["mppt_coordinator"] = mppt_coordinator
-
-                        sensor = create_device_sensor(
-                            device_type=device_type,
-                            coordinator=device_coordinator,
-                            description=sensor_description,
-                            entry_id=config_entry.entry_id,
-                            family_id=device_coordinator.family_id,
-                            family_name=device_coordinator.family_name,
-                            device_id=device_id,
-                            device_info_data=device_info,
-                            **extra_kwargs,
-                        )
-                        # Set status icon
-                        sensor._attr_icon = "mdi:information-outline"
-                        sensors.append(sensor)
-
-                        # For battery devices, create virtual devices for battery modules
-                        if device_type == DEVICE_TYPE_BATTERY:
-                            # Get actual number of battery modules from device coordinator
-                            module_count = device_coordinator.get_battery_module_count(
-                                device_id
-                            )
-
-                            _LOGGER.debug(
-                                "Creating battery module sensors for device %s: %d modules",
-                                device_id,
-                                module_count,
-                            )
-
-                            # Create virtual devices only for existing battery modules
-                            for module_num in range(1, module_count + 1):
-                                # Create sensors for this battery module
-                                for (
-                                    suffix,
-                                    friendly_name,
-                                ) in BATTERY_MODULE_SENSORS.items():
-                                    sensor_key = f"battery{module_num}{suffix}"
-
-                                    sensor_description = build_sensor_description(
-                                        sensor_key, friendly_name
+                            # For battery devices, create virtual devices for battery modules
+                            if device_type == DEVICE_TYPE_BATTERY:
+                                # Get actual number of battery modules from device coordinator
+                                module_count = (
+                                    device_coordinator.get_battery_module_count(
+                                        device_id
                                     )
+                                )
 
-                                    sensor = SunlitBatteryModuleSensor(
-                                        coordinator=device_coordinator,
-                                        description=sensor_description,
-                                        entry_id=config_entry.entry_id,
-                                        family_id=device_coordinator.family_id,
-                                        family_name=device_coordinator.family_name,
-                                        device_id=device_id,
-                                        device_info_data=device_info,
-                                        module_number=module_num,
-                                        mppt_coordinator=mppt_coordinator,
-                                    )
+                                _LOGGER.debug(
+                                    "Creating battery module sensors for device %s: %d modules",
+                                    device_id,
+                                    module_count,
+                                )
 
-                                    # Set icon if available
-                                    icon = get_icon_for_sensor(sensor_key, device_type)
-                                    if icon:
-                                        sensor._attr_icon = icon
-                                    sensors.append(sensor)
+                                # Create virtual devices only for existing battery modules
+                                for module_num in range(1, module_count + 1):
+                                    # Create sensors for this battery module
+                                    for (
+                                        suffix,
+                                        friendly_name,
+                                    ) in BATTERY_MODULE_SENSORS.items():
+                                        sensor_key = f"battery{module_num}{suffix}"
 
-    async_add_entities(sensors, True)
+                                        entity_key = (
+                                            f"{family_id}:{device_id}:{sensor_key}"
+                                        )
+                                        if entity_key in created_keys:
+                                            continue
+                                        created_keys.add(entity_key)
+
+                                        sensor_description = build_sensor_description(
+                                            sensor_key, friendly_name
+                                        )
+
+                                        sensor = SunlitBatteryModuleSensor(
+                                            coordinator=device_coordinator,
+                                            description=sensor_description,
+                                            entry_id=config_entry.entry_id,
+                                            family_id=device_coordinator.family_id,
+                                            family_name=device_coordinator.family_name,
+                                            device_id=device_id,
+                                            device_info_data=device_info,
+                                            module_number=module_num,
+                                            mppt_coordinator=mppt_coordinator,
+                                        )
+
+                                        # Set icon if available
+                                        icon = get_icon_for_sensor(
+                                            sensor_key, device_type
+                                        )
+                                        if icon:
+                                            sensor._attr_icon = icon
+                                        sensors.append(sensor)
+
+        return sensors
+
+    platform_coordinators: list = []
+    for coordinator_set in coordinators.values():
+        if isinstance(coordinator_set, dict):
+            platform_coordinators.append(coordinator_set.get("family"))
+            platform_coordinators.append(coordinator_set.get("device"))
+            platform_coordinators.append(coordinator_set.get("strategy"))
+            platform_coordinators.append(coordinator_set.get("mppt"))
+
+    async_setup_dynamic_entities(
+        config_entry,
+        platform_coordinators,
+        async_add_entities,
+        build_sensors,
+    )

--- a/custom_components/sunlit/sensor.py
+++ b/custom_components/sunlit/sensor.py
@@ -102,7 +102,11 @@ async def async_setup_entry(
                 if "family" in family_coordinator.data:
                     # Skip binary sensor fields (they're handled by binary_sensor platform)
                     skip_fields = {"has_fault", "battery_full"}
-                    family_data = family_coordinator.data["family"]
+                    # Copy: the merges below only determine which keys deserve an
+                    # entity. Each sensor reads its value from its own
+                    # coordinator, so writing the merged keys back into the live
+                    # family payload would pollute it on every update.
+                    family_data = dict(family_coordinator.data["family"])
 
                     # Add strategy data if available
                     if (
@@ -188,9 +192,9 @@ async def async_setup_entry(
 
                 # Create individual device sensors from device coordinator
                 if device_coordinator.data and "devices" in device_coordinator.data:
-                    for device_id, device_data in device_coordinator.data[
-                        "devices"
-                    ].items():
+                    # Sensors come from sensor_map, not from the reported keys,
+                    # so the payload itself is not read here.
+                    for device_id in device_coordinator.data["devices"]:
                         if (
                             device_coordinator.devices
                             and device_id in device_coordinator.devices

--- a/custom_components/sunlit/switch.py
+++ b/custom_components/sunlit/switch.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
+from .dynamic_entities import async_setup_dynamic_entities
 from .entities.device_switch import SunlitBatteryLocalModeSwitch
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,39 +29,63 @@ async def async_setup_entry(
     else:
         coordinators = integration_data
 
-    switches = []
+    def build_switches(created_keys: set[str]) -> list[SunlitBatteryLocalModeSwitch]:
+        """Build switches for batteries not covered yet.
 
-    for family_id, coordinator_set in coordinators.items():
-        if not isinstance(coordinator_set, dict):
-            _LOGGER.warning(
-                "Old coordinator structure detected, skipping family %s", family_id
-            )
-            continue
+        A battery that is offline during startup reports no
+        ``support_local_mode``, so its switch can only be created once the
+        device shows up in a later coordinator update.
+        """
+        switches: list[SunlitBatteryLocalModeSwitch] = []
 
-        device_coordinator = coordinator_set.get("device")
-        if not device_coordinator or not device_coordinator.data:
-            continue
-
-        devices = device_coordinator.data.get("devices", {})
-        for device_id, device_data in devices.items():
-            # Only batteries that advertise local-mode support get a switch.
-            if not device_data.get("support_local_mode"):
-                continue
-            if not (
-                device_coordinator.devices and device_id in device_coordinator.devices
-            ):
-                continue
-
-            device_info = device_coordinator.devices[device_id]
-            switches.append(
-                SunlitBatteryLocalModeSwitch(
-                    coordinator=device_coordinator,
-                    entry_id=config_entry.entry_id,
-                    family_id=device_coordinator.family_id,
-                    family_name=device_coordinator.family_name,
-                    device_id=device_id,
-                    device_info_data=device_info,
+        for family_id, coordinator_set in coordinators.items():
+            if not isinstance(coordinator_set, dict):
+                _LOGGER.warning(
+                    "Old coordinator structure detected, skipping family %s", family_id
                 )
-            )
+                continue
 
-    async_add_entities(switches, True)
+            device_coordinator = coordinator_set.get("device")
+            if not device_coordinator or not device_coordinator.data:
+                continue
+
+            devices = device_coordinator.data.get("devices", {})
+            for device_id, device_data in devices.items():
+                # Only batteries that advertise local-mode support get a switch.
+                if not device_data.get("support_local_mode"):
+                    continue
+                if not (
+                    device_coordinator.devices
+                    and device_id in device_coordinator.devices
+                ):
+                    continue
+
+                key = f"{family_id}:{device_id}:local_mode"
+                if key in created_keys:
+                    continue
+                created_keys.add(key)
+
+                device_info = device_coordinator.devices[device_id]
+                switches.append(
+                    SunlitBatteryLocalModeSwitch(
+                        coordinator=device_coordinator,
+                        entry_id=config_entry.entry_id,
+                        family_id=device_coordinator.family_id,
+                        family_name=device_coordinator.family_name,
+                        device_id=device_id,
+                        device_info_data=device_info,
+                    )
+                )
+
+        return switches
+
+    async_setup_dynamic_entities(
+        config_entry,
+        [
+            coordinator_set.get("device")
+            for coordinator_set in coordinators.values()
+            if isinstance(coordinator_set, dict)
+        ],
+        async_add_entities,
+        build_switches,
+    )

--- a/tests/test_dynamic_entity_creation.py
+++ b/tests/test_dynamic_entity_creation.py
@@ -116,6 +116,51 @@ async def test_family_sensors_are_not_created_twice(
     assert len(keys) == len(set(keys)), "an entity was created more than once"
 
 
+async def test_family_payload_is_not_polluted_by_merges(
+    hass: HomeAssistant,
+    mock_config_entry,
+):
+    """Merging strategy/aggregate keys must not write into the live payload.
+
+    The merged dict only decides which keys deserve an entity; each sensor
+    reads its value from its own coordinator. Since the builder now runs on
+    every update, writing back would keep injecting foreign keys.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    family_coordinator = _family_coordinator({"device_count": 1})
+    device_coordinator = _device_coordinator()
+    device_coordinator.data["aggregates"] = {"total_solar_power": 931.0}
+    _install(hass, mock_config_entry, family_coordinator, device_coordinator)
+
+    async_add_entities = Mock()
+    await sensor_setup_entry(hass, mock_config_entry, async_add_entities)
+
+    assert "total_solar_power" in _added_keys(async_add_entities)
+    assert family_coordinator.data["family"] == {"device_count": 1}
+
+
+async def test_builder_error_does_not_escape_to_the_coordinator(
+    hass: HomeAssistant,
+    mock_config_entry,
+):
+    """A failing build must not break the coordinator's listener dispatch."""
+    mock_config_entry.add_to_hass(hass)
+
+    family_coordinator = _family_coordinator({"device_count": 1})
+    device_coordinator = _device_coordinator()
+    _install(hass, mock_config_entry, family_coordinator, device_coordinator)
+
+    async_add_entities = Mock()
+    await sensor_setup_entry(hass, mock_config_entry, async_add_entities)
+
+    # A malformed payload: the builder iterates devices and will raise.
+    device_coordinator.data["devices"] = "not-a-dict"
+    listener = device_coordinator.async_add_listener.call_args[0][0]
+
+    listener()  # must swallow the error rather than propagate it
+
+
 async def test_device_sensors_created_when_device_appears_later(
     hass: HomeAssistant,
     mock_config_entry,

--- a/tests/test_dynamic_entity_creation.py
+++ b/tests/test_dynamic_entity_creation.py
@@ -1,0 +1,198 @@
+"""Entities must appear when their data does, not only at setup time.
+
+Platform setup runs once. A device that is offline while Home Assistant starts
+contributes no keys to the coordinator snapshot, so anything derived from those
+keys used to be skipped forever — the entity stayed in the registry as
+``restored``/unavailable until the config entry was reloaded by hand, with
+nothing logged to explain it.
+"""
+
+from unittest.mock import MagicMock, Mock
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.sunlit.binary_sensor import (
+    async_setup_entry as binary_sensor_setup_entry,
+)
+from custom_components.sunlit.const import DOMAIN
+from custom_components.sunlit.coordinators.device import SunlitDeviceCoordinator
+from custom_components.sunlit.coordinators.family import SunlitFamilyCoordinator
+from custom_components.sunlit.sensor import async_setup_entry as sensor_setup_entry
+from custom_components.sunlit.switch import async_setup_entry as switch_setup_entry
+
+
+def _family_coordinator(family_data):
+    coordinator = MagicMock(spec=SunlitFamilyCoordinator)
+    coordinator.family_id = "10001"
+    coordinator.family_name = "Test Family"
+    coordinator.devices = {}
+    coordinator.data = {"family": family_data}
+    return coordinator
+
+
+def _device_coordinator(devices=None, device_info=None):
+    coordinator = MagicMock(spec=SunlitDeviceCoordinator)
+    coordinator.family_id = "10001"
+    coordinator.family_name = "Test Family"
+    coordinator.devices = device_info or {}
+    coordinator.data = {"devices": devices or {}, "aggregates": {}}
+    coordinator.get_battery_module_count.return_value = 0
+    return coordinator
+
+
+def _install(hass, entry, family_coordinator, device_coordinator):
+    hass.data[DOMAIN] = {
+        entry.entry_id: {
+            "10001": {
+                "family": family_coordinator,
+                "device": device_coordinator,
+                "strategy": None,
+                "mppt": None,
+            }
+        }
+    }
+
+
+def _added_keys(async_add_entities):
+    """Collect entity_description keys across every add_entities call."""
+    keys = []
+    for call in async_add_entities.call_args_list:
+        for entity in call[0][0]:
+            if hasattr(entity, "entity_description"):
+                keys.append(entity.entity_description.key)
+    return keys
+
+
+async def test_family_sensor_created_when_key_appears_later(
+    hass: HomeAssistant,
+    mock_config_entry,
+):
+    """A key missing at setup still gets its sensor on a later update.
+
+    Mirrors a battery that is offline when HA starts: the cloud omits
+    ``batteryLevel``/``batteryCount``, so ``total_stored_energy`` is absent
+    from the first snapshot.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    family_coordinator = _family_coordinator({"device_count": 1})
+    device_coordinator = _device_coordinator()
+    _install(hass, mock_config_entry, family_coordinator, device_coordinator)
+
+    async_add_entities = Mock()
+    await sensor_setup_entry(hass, mock_config_entry, async_add_entities)
+
+    assert "total_stored_energy" not in _added_keys(async_add_entities)
+
+    # The battery comes online and the family coordinator publishes the key.
+    family_coordinator.data["family"]["total_stored_energy"] = 7.138
+    listener = family_coordinator.async_add_listener.call_args[0][0]
+    listener()
+
+    assert "total_stored_energy" in _added_keys(async_add_entities)
+
+
+async def test_family_sensors_are_not_created_twice(
+    hass: HomeAssistant,
+    mock_config_entry,
+):
+    """Repeated coordinator updates must not duplicate existing entities."""
+    mock_config_entry.add_to_hass(hass)
+
+    family_coordinator = _family_coordinator({"device_count": 1})
+    device_coordinator = _device_coordinator()
+    _install(hass, mock_config_entry, family_coordinator, device_coordinator)
+
+    async_add_entities = Mock()
+    await sensor_setup_entry(hass, mock_config_entry, async_add_entities)
+
+    calls_after_setup = async_add_entities.call_count
+    listener = family_coordinator.async_add_listener.call_args[0][0]
+    listener()
+    listener()
+
+    keys = _added_keys(async_add_entities)
+    assert async_add_entities.call_count == calls_after_setup
+    assert len(keys) == len(set(keys)), "an entity was created more than once"
+
+
+async def test_device_sensors_created_when_device_appears_later(
+    hass: HomeAssistant,
+    mock_config_entry,
+):
+    """A device absent from the first device list still gets its sensors."""
+    mock_config_entry.add_to_hass(hass)
+
+    family_coordinator = _family_coordinator({"device_count": 0})
+    device_coordinator = _device_coordinator()
+    _install(hass, mock_config_entry, family_coordinator, device_coordinator)
+
+    async_add_entities = Mock()
+    await sensor_setup_entry(hass, mock_config_entry, async_add_entities)
+
+    assert "battery_level" not in _added_keys(async_add_entities)
+
+    device_info = {
+        "deviceType": "ENERGY_STORAGE_BATTERY",
+        "deviceSn": "dcbdccc00235",
+    }
+    device_coordinator.devices = {"battery_001": device_info}
+    device_coordinator.data["devices"] = {"battery_001": {"battery_level": 83.0}}
+    listener = device_coordinator.async_add_listener.call_args[0][0]
+    listener()
+
+    assert "battery_level" in _added_keys(async_add_entities)
+
+
+async def test_local_mode_switch_created_when_support_appears_later(
+    hass: HomeAssistant,
+    mock_config_entry,
+):
+    """The local-mode switch appears once the battery advertises support."""
+    mock_config_entry.add_to_hass(hass)
+
+    device_info = {
+        "deviceType": "ENERGY_STORAGE_BATTERY",
+        "deviceSn": "dcbdccc00235",
+    }
+    family_coordinator = _family_coordinator({"device_count": 1})
+    device_coordinator = _device_coordinator(
+        devices={"battery_001": {}},
+        device_info={"battery_001": device_info},
+    )
+    _install(hass, mock_config_entry, family_coordinator, device_coordinator)
+
+    async_add_entities = Mock()
+    await switch_setup_entry(hass, mock_config_entry, async_add_entities)
+
+    assert async_add_entities.call_count == 0
+
+    device_coordinator.data["devices"]["battery_001"]["support_local_mode"] = True
+    listener = device_coordinator.async_add_listener.call_args[0][0]
+    listener()
+
+    switches = async_add_entities.call_args[0][0]
+    assert len(switches) == 1
+
+
+async def test_family_binary_sensor_created_when_key_appears_later(
+    hass: HomeAssistant,
+    mock_config_entry,
+):
+    """Binary sensors follow the same rule as sensors."""
+    mock_config_entry.add_to_hass(hass)
+
+    family_coordinator = _family_coordinator({"device_count": 1})
+    device_coordinator = _device_coordinator()
+    _install(hass, mock_config_entry, family_coordinator, device_coordinator)
+
+    async_add_entities = Mock()
+    await binary_sensor_setup_entry(hass, mock_config_entry, async_add_entities)
+
+    assert "has_fault" not in _added_keys(async_add_entities)
+
+    family_coordinator.data["family"]["has_fault"] = False
+    listener = family_coordinator.async_add_listener.call_args[0][0]
+    listener()
+
+    assert "has_fault" in _added_keys(async_add_entities)


### PR DESCRIPTION
This fixes the problem described in #242: entities that are missing
from the first coordinator payload are never created, because platform setup runs
exactly once and builds its entity list from that single snapshot. On my system a
battery that reconnected two minutes before Home Assistant finished starting left
`total_stored_energy` and the local-mode switch stuck at unavailable for a day,
while the cloud kept serving `"batteryCount": 4` and `"batteryLevel": 83.0`. A
config entry reload produced the correct 7.138 kWh instantly, which is what
pointed at setup timing rather than at the calculation.

The change adds `dynamic_entities.async_setup_dynamic_entities()`, which registers
a listener on the relevant coordinators via `config_entry.async_on_unload()` and
re-runs the platform's builder whenever new data arrives. The builder receives the
set of keys that already have entities and returns only what is missing, so
repeated updates cannot produce duplicates. I deliberately kept creation
data-driven, because only creating entities for hardware that actually reports is
the right behaviour — an install without an EV3600 or a charging box should stay
clean. The only thing that changes is that "not reporting yet" no longer means
"never".

Three platforms needed it. `sensor.py` could lose family keys, entire devices, and
battery module sensors, the last because `get_battery_module_count()` returns 0
for a battery that has not checked in yet. `binary_sensor.py` had the same
snapshot-driven loops for both family and device keys. `switch.py` gates the
local-mode switch on `support_local_mode`, which an offline battery does not
report. I left `select.py`, `number.py` and `calendar.py` alone: they derive their
entities from the existence of a coordinator rather than from payload keys, so
they were never affected.

The new tests in `tests/test_dynamic_entity_creation.py` cover a family key
arriving late, a whole device arriving late, the switch's support flag arriving
late, the binary sensor equivalent, and the guarantee that repeated coordinator
updates create nothing twice. I checked them against `main` first — all five fail
there and pass with this change, so they genuinely pin the behaviour rather than
just passing alongside it. The full suite is at 324 passed with coverage at
81.31%, with the new module fully covered and `sensor.py` at 94.62%. `make lint`
and `make format` are clean.

Closes #242


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sensors, switches, and binary sensors now appear automatically as devices report new data or capabilities.
  * Devices that regain connectivity or enable local control are added without restarting the integration.
  * Newly discovered battery modules and other supported entities are displayed incrementally.

* **Bug Fixes**
  * Prevented duplicate entities from being created during repeated updates.

* **Tests**
  * Added coverage for dynamic discovery and duplicate-prevention scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->